### PR TITLE
Make params properties more concise

### DIFF
--- a/Private/ChatCompletionFunction.ps1
+++ b/Private/ChatCompletionFunction.ps1
@@ -3,7 +3,7 @@ using namespace System.Management.Automation
 function New-ChatCompletionFunctionFromHashTable {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true, Position = 0)]
+        [Parameter(Mandatory, Position = 0)]
         [ValidatePattern('^[a-zA-Z0-9_-]{1,64}$')]
         [string]$Name,
 
@@ -13,7 +13,7 @@ function New-ChatCompletionFunctionFromHashTable {
         [Parameter()]
         [System.Collections.IDictionary]$ParametersHashTable,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ParametersType = 'object'
     )
 

--- a/Private/Convert-ModelToEncoding.ps1
+++ b/Private/Convert-ModelToEncoding.ps1
@@ -2,7 +2,7 @@ function Convert-ModelToEncoding {
     [CmdletBinding()]
     [OutputType([string])]
     param (
-        [Parameter(Mandatory = $true, Position = 0)]
+        [Parameter(Mandatory, Position = 0)]
         [string]$Model
     )
 

--- a/Private/Get-MaskedString.ps1
+++ b/Private/Get-MaskedString.ps1
@@ -4,7 +4,7 @@ function Get-MaskedString {
     [CmdletBinding()]
     [OutputType([string])]
     param (
-        [Parameter(Mandatory, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [AllowEmptyString()]
         [string]$Source,
 

--- a/Private/Invoke-OpenAIAPIRequest.ps1
+++ b/Private/Invoke-OpenAIAPIRequest.ps1
@@ -17,13 +17,13 @@ function Invoke-OpenAIAPIRequest {
         [Parameter()]
         [string]$Method = 'Post',
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [System.Uri]$Uri,
 
         [Parameter()]
         [string]$ContentType = 'application/json',
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNull()]
         [securestring]$ApiKey,
 

--- a/Private/Invoke-OpenAIAPIRequestSSE.ps1
+++ b/Private/Invoke-OpenAIAPIRequestSSE.ps1
@@ -20,13 +20,13 @@ function Invoke-OpenAIAPIRequestSSE {
         [Parameter()]
         [string]$Method = 'Post',
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [System.Uri]$Uri,
 
         [Parameter()]
         [string]$ContentType = 'application/json',
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNull()]
         [securestring]$ApiKey,
 

--- a/Private/Runs/ParseThreadRunObject.ps1
+++ b/Private/Runs/ParseThreadRunObject.ps1
@@ -1,7 +1,7 @@
 function ParseThreadRunObject {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [PSCustomObject]$InputObject,
 
         [Parameter()]

--- a/Private/Runs/ParseThreadRunStepObject.ps1
+++ b/Private/Runs/ParseThreadRunStepObject.ps1
@@ -1,7 +1,7 @@
 function ParseThreadRunStepObject {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [PSCustomObject]$InputObject,
 
         [Parameter()]

--- a/Private/Threads/ParseThreadObject.ps1
+++ b/Private/Threads/ParseThreadObject.ps1
@@ -1,7 +1,7 @@
 function ParseThreadObject {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [PSCustomObject]$InputObject,
 
         [Parameter()]

--- a/Private/Utils.ps1
+++ b/Private/Utils.ps1
@@ -147,14 +147,14 @@ function ParseCommonParams {
 function Get-IdFromInputObject {
     [OutputType([string])]
     param (
-        [Parameter(Mandatory = $true, Position = 0)]
+        [Parameter(Mandatory, Position = 0)]
         [AllowNull()]
         [object]$InputObject,
 
-        [Parameter(Mandatory = $true, Position = 1)]
+        [Parameter(Mandatory, Position = 1)]
         [string]$Prefix,
 
-        [Parameter(Mandatory = $true, Position = 2)]
+        [Parameter(Mandatory, Position = 2)]
         [string]$KeyName
     )
 
@@ -171,7 +171,7 @@ function Get-IdFromInputObject {
 
 function Get-AssistantIdFromInputObject {
     param (
-        [Parameter(Mandatory = $true, Position = 0)]
+        [Parameter(Mandatory, Position = 0)]
         [AllowNull()]
         [object]$InputObject
     )
@@ -180,7 +180,7 @@ function Get-AssistantIdFromInputObject {
 
 function Get-ThreadIdFromInputObject {
     param (
-        [Parameter(Mandatory = $true, Position = 0)]
+        [Parameter(Mandatory, Position = 0)]
         [AllowNull()]
         [object]$InputObject
     )
@@ -189,7 +189,7 @@ function Get-ThreadIdFromInputObject {
 
 function Get-RunIdFromInputObject {
     param (
-        [Parameter(Mandatory = $true, Position = 0)]
+        [Parameter(Mandatory, Position = 0)]
         [AllowNull()]
         [object]$InputObject
     )

--- a/Public/Assistants/Get-Assistant.ps1
+++ b/Public/Assistants/Get-Assistant.ps1
@@ -2,7 +2,7 @@ function Get-Assistant {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(ParameterSetName = 'Get', Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'Get', Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('assistant_id')]
         [Alias('Assistant')]
         [ValidateScript({ [bool](Get-AssistantIdFromInputObject $_) })]
@@ -15,10 +15,10 @@ function Get-Assistant {
         [Parameter(ParameterSetName = 'ListAll')]
         [switch]$All,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$After,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$Before,
 
         [Parameter(ParameterSetName = 'List')]
@@ -33,16 +33,16 @@ function Get-Assistant {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Assistants/New-Assistant.ps1
+++ b/Public/Assistants/New-Assistant.ps1
@@ -3,7 +3,7 @@ function New-Assistant {
     [OutputType([pscustomobject])]
     param (
         # Hidden param, for Set-Assistants cmdlet
-        [Parameter(DontShow = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(DontShow, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Object]$InputObject,
 
         [Parameter()]
@@ -63,16 +63,16 @@ function New-Assistant {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Assistants/Remove-Assistant.ps1
+++ b/Public/Assistants/Remove-Assistant.ps1
@@ -2,7 +2,7 @@ function Remove-Assistant {
     [CmdletBinding()]
     [OutputType([void])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('assistant_id')]
         [Alias('Assistant')]
         [ValidateScript({ [bool](Get-AssistantIdFromInputObject $_) })]
@@ -15,16 +15,16 @@ function Remove-Assistant {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Assistants/Set-Assistant.ps1
+++ b/Public/Assistants/Set-Assistant.ps1
@@ -2,7 +2,7 @@ function Set-Assistant {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('assistant_id')]
         [Alias('Assistant')]
         [ValidateScript({ [bool](Get-AssistantIdFromInputObject $_) })]
@@ -62,16 +62,16 @@ function Set-Assistant {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Azure/Assistants/Get-AzureAssistant.ps1
+++ b/Public/Azure/Assistants/Get-AzureAssistant.ps1
@@ -2,7 +2,7 @@ function Get-AzureAssistant {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(ParameterSetName = 'Get', Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'Get', Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('assistant_id')]
         [Alias('Assistant')]
         [ValidateScript({ [bool](Get-AssistantIdFromInputObject $_) })]
@@ -15,10 +15,10 @@ function Get-AzureAssistant {
         [Parameter(ParameterSetName = 'ListAll')]
         [switch]$All,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$After,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$Before,
 
         [Parameter(ParameterSetName = 'List')]

--- a/Public/Azure/Assistants/New-AzureAssistant.ps1
+++ b/Public/Azure/Assistants/New-AzureAssistant.ps1
@@ -3,14 +3,14 @@ function New-AzureAssistant {
     [OutputType([pscustomobject])]
     param (
         # Hidden param, for Set-Assistants cmdlet
-        [Parameter(DontShow = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(DontShow, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Object]$InputObject,
 
         [Parameter()]
         [ValidateLength(0, 256)]
         [string]$Name,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias('Model')]
         [string]$Deployment,
 

--- a/Public/Azure/Assistants/Remove-AzureAssistant.ps1
+++ b/Public/Azure/Assistants/Remove-AzureAssistant.ps1
@@ -2,7 +2,7 @@ function Remove-AzureAssistant {
     [CmdletBinding()]
     [OutputType([void])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('assistant_id')]
         [Alias('Assistant')]
         [ValidateScript({ [bool](Get-AssistantIdFromInputObject $_) })]

--- a/Public/Azure/Assistants/Set-AzureAssistant.ps1
+++ b/Public/Azure/Assistants/Set-AzureAssistant.ps1
@@ -2,7 +2,7 @@ function Set-AzureAssistant {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('assistant_id')]
         [Alias('Assistant')]
         [ValidateScript({ [bool](Get-AssistantIdFromInputObject $_) })]

--- a/Public/Azure/Files/Get-AzureOpenAIFile.ps1
+++ b/Public/Azure/Files/Get-AzureOpenAIFile.ps1
@@ -2,7 +2,7 @@ function Get-AzureOpenAIFile {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(ParameterSetName = 'Get', Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'Get', Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('file_id')]
         [ValidateNotNullOrEmpty()]
         [string][UrlEncodeTransformation()]$Id,

--- a/Public/Azure/Files/Get-AzureOpenAIFileContent.ps1
+++ b/Public/Azure/Files/Get-AzureOpenAIFileContent.ps1
@@ -2,7 +2,7 @@ function Get-AzureOpenAIFileContent {
     [CmdletBinding()]
     [OutputType([byte[]])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('file_id')]
         [ValidateNotNullOrEmpty()]
         [string][UrlEncodeTransformation()]$Id,

--- a/Public/Azure/Files/Register-AzureOpenAIFile.ps1
+++ b/Public/Azure/Files/Register-AzureOpenAIFile.ps1
@@ -2,11 +2,11 @@ function Register-AzureOpenAIFile {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateScript({ Test-Path -LiteralPath $_ -PathType Leaf })]
         [string]$File,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Completions('assistants', 'fine-tune')]
         [ValidateNotNullOrEmpty()]
         [string][LowerCaseTransformation()]$Purpose,

--- a/Public/Azure/Files/Remove-AzureOpenAIFile.ps1
+++ b/Public/Azure/Files/Remove-AzureOpenAIFile.ps1
@@ -2,7 +2,7 @@ function Remove-AzureOpenAIFile {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('file_id')]
         [ValidateNotNullOrEmpty()]
         [string][UrlEncodeTransformation()]$Id,

--- a/Public/Azure/Get-AzureOpenAIModels.ps1
+++ b/Public/Azure/Get-AzureOpenAIModels.ps1
@@ -2,7 +2,7 @@ function Get-AzureOpenAIModels {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Position = 0, ValueFromPipeline)]
         [Alias('ID')]
         [Alias('Model')]
         [string][LowerCaseTransformation()]$Name,

--- a/Public/Azure/Request-AzureAudioSpeech.ps1
+++ b/Public/Azure/Request-AzureAudioSpeech.ps1
@@ -2,17 +2,17 @@ function Request-AzureAudioSpeech {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     [OutputType([void])]
     param (
-        [Parameter(ParameterSetName = 'Default', Mandatory = $true, Position = 0)]
+        [Parameter(ParameterSetName = 'Default', Mandatory, Position = 0)]
         [Alias('Input')]
         [ValidateNotNullOrEmpty()]
         [string]$Text,
 
         # For pipeline input from chat completion
-        [Parameter(ParameterSetName = 'Pipeline', DontShow = $true, Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(ParameterSetName = 'Pipeline', DontShow, Mandatory, ValueFromPipeline)]
         [ValidateNotNull()]
         [Object]$InputObject,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias('Model')]
         [string]$Deployment,
 
@@ -39,7 +39,7 @@ function Request-AzureAudioSpeech {
         )]
         [string][LowerCaseTransformation()]$Format,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$OutFile,
 

--- a/Public/Azure/Request-AzureAudioTranscription.ps1
+++ b/Public/Azure/Request-AzureAudioTranscription.ps1
@@ -2,11 +2,11 @@ function Request-AzureAudioTranscription {
     [CmdletBinding(DefaultParameterSetName = 'Language')]
     [OutputType([string])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateScript({ Test-Path -LiteralPath $_ -PathType Leaf })]
         [string]$File,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias('Model')]
         [string]$Deployment,
 
@@ -25,7 +25,7 @@ function Request-AzureAudioTranscription {
         [Parameter(ParameterSetName = 'Language')]
         [string]$Language,
 
-        [Parameter(DontShow = $true, ParameterSetName = 'LiteralLanguage')]
+        [Parameter(DontShow, ParameterSetName = 'LiteralLanguage')]
         [string]$LiteralLanguage,
 
         [Parameter()]

--- a/Public/Azure/Request-AzureAudioTranslation.ps1
+++ b/Public/Azure/Request-AzureAudioTranslation.ps1
@@ -2,11 +2,11 @@ function Request-AzureAudioTranslation {
     [CmdletBinding(DefaultParameterSetName = 'Language')]
     [OutputType([string])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateScript({ Test-Path -LiteralPath $_ -PathType Leaf })]
         [string]$File,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias('Model')]
         [string]$Deployment,
 

--- a/Public/Azure/Request-AzureChatCompletion.ps1
+++ b/Public/Azure/Request-AzureChatCompletion.ps1
@@ -3,7 +3,7 @@ function Request-AzureChatCompletion {
     [OutputType([pscustomobject])]
     [Alias('Request-AzureChatGPT')]
     param (
-        [Parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $false, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('Text')]
         [ValidateNotNullOrEmpty()]
         [string]$Message,
@@ -17,7 +17,7 @@ function Request-AzureChatCompletion {
         [ValidatePattern('^[a-zA-Z0-9_-]{1,64}$')]   # May contain a-z, A-Z, 0-9, hyphens, and underscores, with a maximum length of 64 characters.
         [string]$Name,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias('Model')]
         [string]$Deployment,
 
@@ -41,7 +41,7 @@ function Request-AzureChatCompletion {
         [System.Collections.IDictionary[]]$Tools,
 
         # deprecated
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [ValidateNotNullOrEmpty()]
         [System.Collections.IDictionary[]]$Functions,
 
@@ -51,7 +51,7 @@ function Request-AzureChatCompletion {
         [object]$ToolChoice,
 
         # deprecated
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [Alias('function_call')]
         [Completions('none', 'auto')]
         [object]$FunctionCall,
@@ -62,7 +62,7 @@ function Request-AzureChatCompletion {
         [string]$InvokeTools = 'None',
 
         # deprecated
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [uint16]$MaxFunctionCallCount,
         #endregion Function call params
 
@@ -137,7 +137,7 @@ function Request-AzureChatCompletion {
         [ValidateSet('azure', 'azure_ad')]
         [string]$AuthType = 'azure',
 
-        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [object[]]$History,
 
         [Parameter()]

--- a/Public/Azure/Request-AzureEmbeddings.ps1
+++ b/Public/Azure/Request-AzureEmbeddings.ps1
@@ -7,12 +7,12 @@ function Request-AzureEmbeddings {
           But avoid using the variable name $Input for variable name,
           because it is used as an automatic variable in PowerShell.
         #>
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [Alias('Input')]
         [string[]]$Text,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias('Model')]
         [string]$Deployment,
 

--- a/Public/Azure/Request-AzureImageGeneration.ps1
+++ b/Public/Azure/Request-AzureImageGeneration.ps1
@@ -1,7 +1,7 @@
 function Request-AzureImageGeneration {
     [CmdletBinding(DefaultParameterSetName = 'Format')]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [string]$Prompt,
 
@@ -32,7 +32,7 @@ function Request-AzureImageGeneration {
         [ValidateSet('url', 'base64', 'byte', 'raw_response')]
         [string]$Format = 'url',
 
-        [Parameter(ParameterSetName = 'OutFile', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'OutFile', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$OutFile,
 

--- a/Public/Azure/Request-AzureTextCompletion.ps1
+++ b/Public/Azure/Request-AzureTextCompletion.ps1
@@ -2,7 +2,7 @@ function Request-AzureTextCompletion {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Position = 0, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [Alias('Message')]
         [string[]]$Prompt,
@@ -10,7 +10,7 @@ function Request-AzureTextCompletion {
         [Parameter()]
         [string]$Suffix,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias('Model')]
         [string]$Deployment,
 

--- a/Public/Azure/Runs/Get-AzureThreadRun.ps1
+++ b/Public/Azure/Runs/Get-AzureThreadRun.ps1
@@ -2,12 +2,12 @@ function Get-AzureThreadRun {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(ParameterSetName = 'Get', Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'Get', Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('run_id')]
         [ValidateNotNullOrEmpty()]
         [string][UrlEncodeTransformation()]$RunId,
 
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('thread_id')]
         [Alias('Thread')]
         [ValidateScript({ [bool](Get-ThreadIdFromInputObject $_) })]
@@ -20,10 +20,10 @@ function Get-AzureThreadRun {
         [Parameter(ParameterSetName = 'ListAll')]
         [switch]$All,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$After,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$Before,
 
         [Parameter(ParameterSetName = 'List')]
@@ -38,7 +38,7 @@ function Get-AzureThreadRun {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [switch]$Primitive,
 
         [Parameter()]

--- a/Public/Azure/Runs/Get-AzureThreadRunStep.ps1
+++ b/Public/Azure/Runs/Get-AzureThreadRunStep.ps1
@@ -2,12 +2,12 @@ function Get-AzureThreadRunStep {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(ParameterSetName = 'Get', Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'Get', Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('step_id')]
         [ValidateNotNullOrEmpty()]
         [string][UrlEncodeTransformation()]$StepId,
 
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateScript({ ([string]$_.id).StartsWith('run_', [StringComparison]::Ordinal) -and ([string]$_.thread_id).StartsWith('thread_', [StringComparison]::Ordinal) })]
         [Alias('Run')]
         [Object]$InputObject,
@@ -19,10 +19,10 @@ function Get-AzureThreadRunStep {
         [Parameter(ParameterSetName = 'ListAll')]
         [switch]$All,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$After,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$Before,
 
         [Parameter(ParameterSetName = 'List')]

--- a/Public/Azure/Runs/Receive-AzureThreadRun.ps1
+++ b/Public/Azure/Runs/Receive-AzureThreadRun.ps1
@@ -2,7 +2,7 @@ function Receive-AzureThreadRun {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateScript({ ([string]$_.id).StartsWith('run_', [StringComparison]::Ordinal) -and ([string]$_.thread_id).StartsWith('thread_', [StringComparison]::Ordinal) })]
         [Alias('Run')]
         [Object]$InputObject,

--- a/Public/Azure/Runs/Start-AzureThreadRun.ps1
+++ b/Public/Azure/Runs/Start-AzureThreadRun.ps1
@@ -2,13 +2,13 @@ function Start-AzureThreadRun {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('thread_id')]
         [Alias('Thread')]
         [ValidateScript({ [bool](Get-ThreadIdFromInputObject $_) })]
         [Object]$InputObject,
 
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('assistant_id')]
         [ValidateScript({ [bool](Get-AssistantIdFromInputObject $_) })]
         [Object]$Assistant,

--- a/Public/Azure/Runs/Stop-AzureThreadRun.ps1
+++ b/Public/Azure/Runs/Stop-AzureThreadRun.ps1
@@ -2,7 +2,7 @@ function Stop-AzureThreadRun {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateScript({ ([string]$_.id).StartsWith('run_', [StringComparison]::Ordinal) -and ([string]$_.thread_id).StartsWith('thread_', [StringComparison]::Ordinal) })]
         [Alias('Run')]
         [Object]$InputObject,

--- a/Public/Azure/Runs/Submit-AzureToolOutput.ps1
+++ b/Public/Azure/Runs/Submit-AzureToolOutput.ps1
@@ -2,12 +2,12 @@ function Submit-AzureToolOutput {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateScript({ ([string]$_.id).StartsWith('run_', [StringComparison]::Ordinal) -and ([string]$_.thread_id).StartsWith('thread_', [StringComparison]::Ordinal) })]
         [Alias('Run')]
         [Object]$InputObject,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [AllowEmptyCollection()]
         [System.Collections.IDictionary[]]$ToolOutput,
 

--- a/Public/Azure/Runs/Wait-AzureThreadRun.ps1
+++ b/Public/Azure/Runs/Wait-AzureThreadRun.ps1
@@ -2,7 +2,7 @@ function Wait-AzureThreadRun {
     [CmdletBinding(DefaultParameterSetName = 'StatusForWait')]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateScript({ ([string]$_.id).StartsWith('run_', [StringComparison]::Ordinal) -and ([string]$_.thread_id).StartsWith('thread_', [StringComparison]::Ordinal) })]
         [Alias('Run')]
         [Object]$InputObject,

--- a/Public/Azure/Threads/Add-AzureThreadMessage.ps1
+++ b/Public/Azure/Threads/Add-AzureThreadMessage.ps1
@@ -2,13 +2,13 @@ function Add-AzureThreadMessage {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('thread_id')]
         [Alias('Thread')]
         [ValidateScript({ [bool](Get-ThreadIdFromInputObject $_) })]
         [Object]$InputObject,
 
-        [Parameter(Mandatory = $true, Position = 0)]
+        [Parameter(Mandatory, Position = 0)]
         [Alias('Text')]
         [Alias('Content')]
         [ValidateNotNullOrEmpty()]

--- a/Public/Azure/Threads/Get-AzureThread.ps1
+++ b/Public/Azure/Threads/Get-AzureThread.ps1
@@ -2,7 +2,7 @@ function Get-AzureThread {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('thread_id')]
         [Alias('Thread')]
         [ValidateScript({ [bool](Get-ThreadIdFromInputObject $_) })]
@@ -28,7 +28,7 @@ function Get-AzureThread {
         [Parameter()]
         [securestring][SecureStringTransformation()]$ApiKey,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [switch]$Primitive,
 
         [Parameter()]

--- a/Public/Azure/Threads/Get-AzureThreadMessage.ps1
+++ b/Public/Azure/Threads/Get-AzureThreadMessage.ps1
@@ -2,13 +2,13 @@ function Get-AzureThreadMessage {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('thread_id')]
         [Alias('Thread')]
         [ValidateScript({ [bool](Get-ThreadIdFromInputObject $_) })]
         [Object]$InputObject,
 
-        [Parameter(ParameterSetName = 'Get', Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'Get', Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('message_id')]
         [ValidateNotNullOrEmpty()]
         [string][UrlEncodeTransformation()]$MessageId,
@@ -20,10 +20,10 @@ function Get-AzureThreadMessage {
         [Parameter(ParameterSetName = 'ListAll')]
         [switch]$All,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$After,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$Before,
 
         [Parameter(ParameterSetName = 'List')]

--- a/Public/Azure/Threads/New-AzureThread.ps1
+++ b/Public/Azure/Threads/New-AzureThread.ps1
@@ -3,10 +3,10 @@ function New-AzureThread {
     [OutputType([pscustomobject])]
     param (
         # Hidden param, for Set-Thread cmdlet
-        [Parameter(DontShow = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(DontShow, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Object]$InputObject,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [object[]]$Messages,
 
         [Parameter()]

--- a/Public/Azure/Threads/Remove-AzureThread.ps1
+++ b/Public/Azure/Threads/Remove-AzureThread.ps1
@@ -2,7 +2,7 @@ function Remove-AzureThread {
     [CmdletBinding()]
     [OutputType([void])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('thread_id')]
         [Alias('Thread')]
         [ValidateScript({ [bool](Get-ThreadIdFromInputObject $_) })]

--- a/Public/Azure/Threads/Set-AzureThread.ps1
+++ b/Public/Azure/Threads/Set-AzureThread.ps1
@@ -2,7 +2,7 @@ function Set-AzureThread {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('thread_id')]
         [Alias('Thread')]
         [ValidateScript({ [bool](Get-ThreadIdFromInputObject $_) })]

--- a/Public/ConvertFrom-Token.ps1
+++ b/Public/ConvertFrom-Token.ps1
@@ -2,11 +2,11 @@ function ConvertFrom-Token {
     [CmdletBinding(DefaultParameterSetName = 'encoding')]
     [OutputType([string])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [AllowEmptyCollection()]
         [int[]]$Token,
 
-        [Parameter(Mandatory = $true, Position = 1, ParameterSetName = 'model')]
+        [Parameter(Mandatory, Position = 1, ParameterSetName = 'model')]
         [string][LowerCaseTransformation()]$Model,
 
         [Parameter(Mandatory = $false, Position = 1, ParameterSetName = 'encoding')]

--- a/Public/ConvertTo-Token.ps1
+++ b/Public/ConvertTo-Token.ps1
@@ -2,11 +2,11 @@ function ConvertTo-Token {
     [CmdletBinding(DefaultParameterSetName = 'encoding')]
     [OutputType([int[]])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [AllowEmptyString()]
         [string]$Text,
 
-        [Parameter(Mandatory = $true, Position = 1, ParameterSetName = 'model')]
+        [Parameter(Mandatory, Position = 1, ParameterSetName = 'model')]
         [string][LowerCaseTransformation()]$Model,
 
         [Parameter(Mandatory = $false, Position = 1, ParameterSetName = 'encoding')]

--- a/Public/Enter-ChatGPT.ps1
+++ b/Public/Enter-ChatGPT.ps1
@@ -56,16 +56,16 @@ function Enter-ChatGPT {
         [Parameter()]
         [int]$TimeoutSec = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Files/Get-OpenAIFile.ps1
+++ b/Public/Files/Get-OpenAIFile.ps1
@@ -2,7 +2,7 @@ function Get-OpenAIFile {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(ParameterSetName = 'Get', Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'Get', Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('file_id')]
         [ValidateNotNullOrEmpty()]
         [string][UrlEncodeTransformation()]$Id,
@@ -19,16 +19,16 @@ function Get-OpenAIFile {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Files/Get-OpenAIFileContent.ps1
+++ b/Public/Files/Get-OpenAIFileContent.ps1
@@ -2,7 +2,7 @@ function Get-OpenAIFileContent {
     [CmdletBinding()]
     [OutputType([byte[]])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('file_id')]
         [ValidateNotNullOrEmpty()]
         [string][UrlEncodeTransformation()]$Id,
@@ -18,16 +18,16 @@ function Get-OpenAIFileContent {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Files/Register-OpenAIFile.ps1
+++ b/Public/Files/Register-OpenAIFile.ps1
@@ -2,11 +2,11 @@ function Register-OpenAIFile {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateScript({ Test-Path -LiteralPath $_ -PathType Leaf })]
         [string]$File,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Completions('assistants', 'fine-tune')]
         [ValidateNotNullOrEmpty()]
         [string][LowerCaseTransformation()]$Purpose,
@@ -18,16 +18,16 @@ function Register-OpenAIFile {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Files/Remove-OpenAIFile.ps1
+++ b/Public/Files/Remove-OpenAIFile.ps1
@@ -2,7 +2,7 @@ function Remove-OpenAIFile {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('file_id')]
         [ValidateNotNullOrEmpty()]
         [string][UrlEncodeTransformation()]$Id,
@@ -14,16 +14,16 @@ function Remove-OpenAIFile {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Get-OpenAIModels.ps1
+++ b/Public/Get-OpenAIModels.ps1
@@ -2,7 +2,7 @@ function Get-OpenAIModels {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Position = 0, ValueFromPipeline)]
         [Alias('ID')]
         [Alias('Model')]
         [string][LowerCaseTransformation()]$Name,
@@ -14,16 +14,16 @@ function Get-OpenAIModels {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/New-ChatCompletionFunction.ps1
+++ b/Public/New-ChatCompletionFunction.ps1
@@ -2,11 +2,11 @@ function New-ChatCompletionFunction {
     [OutputType([System.Collections.Specialized.OrderedDictionary])]
     [CmdletBinding(DefaultParameterSetName = 'PSCommand')]
     param (
-        # [Parameter(ParameterSetName = 'Manual' , Mandatory = $true, Position = 0)]
+        # [Parameter(ParameterSetName = 'Manual' , Mandatory, Position = 0)]
         # [ValidatePattern('^[a-zA-Z0-9_-]{1,64}$')]
         # [string]$Name,
 
-        [Parameter(ParameterSetName = 'PSCommand' , Mandatory = $true, Position = 0)]
+        [Parameter(ParameterSetName = 'PSCommand' , Mandatory, Position = 0)]
         [ValidatePattern('^[a-zA-Z0-9_-]{1,64}$')]
         [ValidateScript({ (Get-Command $_ -ea Ignore) -is [CommandInfo] })]
         [string]$Command,
@@ -18,7 +18,7 @@ function New-ChatCompletionFunction {
         # [Parameter(ParameterSetName = 'Manual')]
         # [System.Collections.IDictionary]$ParametersHashTable,
 
-        # [Parameter(ParameterSetName = 'Manual', DontShow = $true)]
+        # [Parameter(ParameterSetName = 'Manual', DontShow)]
         # [string]$ParametersType = 'object',
 
         [Parameter(ParameterSetName = 'PSCommand')]

--- a/Public/Request-AudioSpeech.ps1
+++ b/Public/Request-AudioSpeech.ps1
@@ -2,13 +2,13 @@ function Request-AudioSpeech {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     [OutputType([void])]
     param (
-        [Parameter(ParameterSetName = 'Default', Mandatory = $true, Position = 0)]
+        [Parameter(ParameterSetName = 'Default', Mandatory, Position = 0)]
         [Alias('Input')]
         [ValidateNotNullOrEmpty()]
         [string]$Text,
 
         # For pipeline input from chat completion
-        [Parameter(ParameterSetName = 'Pipeline', DontShow = $true, Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(ParameterSetName = 'Pipeline', DontShow, Mandatory, ValueFromPipeline)]
         [ValidateNotNull()]
         [Object]$InputObject,
 
@@ -39,7 +39,7 @@ function Request-AudioSpeech {
         )]
         [string][LowerCaseTransformation()]$Format,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$OutFile,
 
@@ -54,16 +54,16 @@ function Request-AudioSpeech {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Request-AudioTranscription.ps1
+++ b/Public/Request-AudioTranscription.ps1
@@ -2,7 +2,7 @@ function Request-AudioTranscription {
     [CmdletBinding(DefaultParameterSetName = 'Language')]
     [OutputType([string])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateScript({ Test-Path -LiteralPath $_ -PathType Leaf })]
         [string]$File,
 
@@ -30,7 +30,7 @@ function Request-AudioTranscription {
         [Parameter(ParameterSetName = 'Language')]
         [string]$Language,
 
-        [Parameter(DontShow = $true, ParameterSetName = 'LiteralLanguage')]
+        [Parameter(DontShow, ParameterSetName = 'LiteralLanguage')]
         [string]$LiteralLanguage,
 
         [Parameter()]
@@ -40,16 +40,16 @@ function Request-AudioTranscription {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Request-AudioTranslation.ps1
+++ b/Public/Request-AudioTranslation.ps1
@@ -2,7 +2,7 @@ function Request-AudioTranslation {
     [CmdletBinding(DefaultParameterSetName = 'Language')]
     [OutputType([string])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateScript({ Test-Path -LiteralPath $_ -PathType Leaf })]
         [string]$File,
 
@@ -29,16 +29,16 @@ function Request-AudioTranslation {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Request-ChatCompletion.ps1
+++ b/Public/Request-ChatCompletion.ps1
@@ -3,7 +3,7 @@ function Request-ChatCompletion {
     [OutputType([pscustomobject])]
     [Alias('Request-ChatGPT')]
     param (
-        [Parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $false, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('Text')]
         [ValidateNotNullOrEmpty()]
         [string]$Message,
@@ -54,7 +54,7 @@ function Request-ChatCompletion {
         [System.Collections.IDictionary[]]$Tools,
 
         # deprecated
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [ValidateNotNullOrEmpty()]
         [System.Collections.IDictionary[]]$Functions,
 
@@ -64,7 +64,7 @@ function Request-ChatCompletion {
         [object]$ToolChoice,
 
         # deprecated
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [Alias('function_call')]
         [Completions('none', 'auto')]
         [object]$FunctionCall,
@@ -75,7 +75,7 @@ function Request-ChatCompletion {
         [string]$InvokeTools = 'None',
 
         # deprecated
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [uint16]$MaxFunctionCallCount,
         #endregion Function call params
 
@@ -145,16 +145,16 @@ function Request-ChatCompletion {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]
@@ -164,7 +164,7 @@ function Request-ChatCompletion {
         [Alias('OrgId')]
         [string]$Organization,
 
-        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [object[]]$History,
 
         [Parameter()]

--- a/Public/Request-Embeddings.ps1
+++ b/Public/Request-Embeddings.ps1
@@ -7,7 +7,7 @@ function Request-Embeddings {
           But avoid using the variable name $Input for variable name,
           because it is used as an automatic variable in PowerShell.
         #>
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [Alias('Input')]
         [string[]]$Text,
@@ -35,16 +35,16 @@ function Request-Embeddings {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Request-ImageEdit.ps1
+++ b/Public/Request-ImageEdit.ps1
@@ -1,7 +1,7 @@
 function Request-ImageEdit {
     [CmdletBinding(DefaultParameterSetName = 'Format')]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias('File')]
         [ValidateScript({ Test-Path -LiteralPath $_ -PathType Leaf })]
         [string]$Image,
@@ -10,7 +10,7 @@ function Request-ImageEdit {
         [ValidateScript({ Test-Path -LiteralPath $_ -PathType Leaf })]
         [string]$Mask,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateLength(1, 1000)]
         [string]$Prompt,
 
@@ -28,7 +28,7 @@ function Request-ImageEdit {
         [ValidateSet('url', 'base64', 'byte')]
         [string]$Format = 'url',
 
-        [Parameter(ParameterSetName = 'OutFile', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'OutFile', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$OutFile,
 
@@ -38,16 +38,16 @@ function Request-ImageEdit {
         [Parameter()]
         [int]$TimeoutSec = 0,
 
-        # [Parameter(DontShow = $true)]
+        # [Parameter(DontShow)]
         # [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        # [Parameter(DontShow = $true)]
+        # [Parameter(DontShow)]
         # [string]$ApiVersion,
 
-        # [Parameter(DontShow = $true)]
+        # [Parameter(DontShow)]
         # [string]$AuthType = 'openai',
 
 

--- a/Public/Request-ImageGeneration.ps1
+++ b/Public/Request-ImageGeneration.ps1
@@ -1,7 +1,7 @@
 function Request-ImageGeneration {
     [CmdletBinding(DefaultParameterSetName = 'Format')]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [string]$Prompt,
 
@@ -34,7 +34,7 @@ function Request-ImageGeneration {
         [ValidateSet('url', 'base64', 'byte', 'raw_response')]
         [string]$Format = 'url',
 
-        [Parameter(ParameterSetName = 'OutFile', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'OutFile', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$OutFile,
 
@@ -44,16 +44,16 @@ function Request-ImageGeneration {
         [Parameter()]
         [int]$TimeoutSec = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Request-ImageVariation.ps1
+++ b/Public/Request-ImageVariation.ps1
@@ -1,7 +1,7 @@
 function Request-ImageVariation {
     [CmdletBinding(DefaultParameterSetName = 'Format')]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [Alias('File')]
         [ValidateScript({ Test-Path -LiteralPath $_ -PathType Leaf })]
         [string]$Image,
@@ -20,7 +20,7 @@ function Request-ImageVariation {
         [ValidateSet('url', 'base64', 'byte')]
         [string]$Format = 'url',
 
-        [Parameter(ParameterSetName = 'OutFile', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'OutFile', Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$OutFile,
 
@@ -30,16 +30,16 @@ function Request-ImageVariation {
         [Parameter()]
         [int]$TimeoutSec = 0,
 
-        # [Parameter(DontShow = $true)]
+        # [Parameter(DontShow)]
         # [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        # [Parameter(DontShow = $true)]
+        # [Parameter(DontShow)]
         # [string]$ApiVersion,
 
-        # [Parameter(DontShow = $true)]
+        # [Parameter(DontShow)]
         # [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Request-Moderation.ps1
+++ b/Public/Request-Moderation.ps1
@@ -7,7 +7,7 @@ function Request-Moderation {
           But avoid using the variable name $Input for variable name,
           because it is used as an automatic variable in PowerShell.
         #>
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [Alias('Input')]
         [string[]]$Text,

--- a/Public/Request-TextCompletion.ps1
+++ b/Public/Request-TextCompletion.ps1
@@ -2,7 +2,7 @@ function Request-TextCompletion {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Position = 0, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [Alias('Message')]
         [string[]]$Prompt,
@@ -67,16 +67,16 @@ function Request-TextCompletion {
         [Parameter()]
         [int]$TimeoutSec = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Runs/Get-ThreadRun.ps1
+++ b/Public/Runs/Get-ThreadRun.ps1
@@ -2,12 +2,12 @@ function Get-ThreadRun {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(ParameterSetName = 'Get', Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'Get', Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('run_id')]
         [ValidateNotNullOrEmpty()]
         [string][UrlEncodeTransformation()]$RunId,
 
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('thread_id')]
         [Alias('Thread')]
         [ValidateScript({ [bool](Get-ThreadIdFromInputObject $_) })]
@@ -20,10 +20,10 @@ function Get-ThreadRun {
         [Parameter(ParameterSetName = 'ListAll')]
         [switch]$All,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$After,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$Before,
 
         [Parameter(ParameterSetName = 'List')]
@@ -38,16 +38,16 @@ function Get-ThreadRun {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]
@@ -57,7 +57,7 @@ function Get-ThreadRun {
         [Alias('OrgId')]
         [string]$Organization,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [switch]$Primitive,
 
         [Parameter()]

--- a/Public/Runs/Get-ThreadRunStep.ps1
+++ b/Public/Runs/Get-ThreadRunStep.ps1
@@ -2,12 +2,12 @@ function Get-ThreadRunStep {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(ParameterSetName = 'Get', Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'Get', Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('step_id')]
         [ValidateNotNullOrEmpty()]
         [string][UrlEncodeTransformation()]$StepId,
 
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateScript({ ([string]$_.id).StartsWith('run_', [StringComparison]::Ordinal) -and ([string]$_.thread_id).StartsWith('thread_', [StringComparison]::Ordinal) })]
         [Alias('Run')]
         [Object]$InputObject,
@@ -19,10 +19,10 @@ function Get-ThreadRunStep {
         [Parameter(ParameterSetName = 'ListAll')]
         [switch]$All,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$After,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$Before,
 
         [Parameter(ParameterSetName = 'List')]
@@ -37,16 +37,16 @@ function Get-ThreadRunStep {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Runs/Receive-ThreadRun.ps1
+++ b/Public/Runs/Receive-ThreadRun.ps1
@@ -2,7 +2,7 @@ function Receive-ThreadRun {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateScript({ ([string]$_.id).StartsWith('run_', [StringComparison]::Ordinal) -and ([string]$_.thread_id).StartsWith('thread_', [StringComparison]::Ordinal) })]
         [Alias('Run')]
         [Object]$InputObject,
@@ -14,16 +14,16 @@ function Receive-ThreadRun {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Runs/Start-ThreadRun.ps1
+++ b/Public/Runs/Start-ThreadRun.ps1
@@ -2,14 +2,14 @@ function Start-ThreadRun {
     [CmdletBinding(DefaultParameterSetName = 'ThreadAndRun')]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Run')]
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Run_Stream')]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName, ParameterSetName = 'Run')]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName, ParameterSetName = 'Run_Stream')]
         [Alias('thread_id')]
         [Alias('Thread')]
         [ValidateScript({ [bool](Get-ThreadIdFromInputObject $_) })]
         [Object]$InputObject,
 
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('assistant_id')]
         [ValidateScript({ [bool](Get-AssistantIdFromInputObject $_) })]
         [Object]$Assistant,
@@ -46,8 +46,8 @@ function Start-ThreadRun {
         [object[]]$AdditionalMessages,
 
         #region Parameters for Thread and Run
-        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = 'ThreadAndRun')]
-        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = 'ThreadAndRun_Stream')]
+        [Parameter(Mandatory, Position = 0, ParameterSetName = 'ThreadAndRun')]
+        [Parameter(Mandatory, Position = 0, ParameterSetName = 'ThreadAndRun_Stream')]
         [Alias('Text')]
         [Alias('Content')]
         [ValidateNotNullOrEmpty()]
@@ -111,8 +111,8 @@ function Start-ThreadRun {
         [ValidateRange(0.0, 2.0)]
         [double]$Temperature,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'Run_Stream')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'ThreadAndRun_Stream')]
+        [Parameter(Mandatory, ParameterSetName = 'Run_Stream')]
+        [Parameter(Mandatory, ParameterSetName = 'ThreadAndRun_Stream')]
         [switch]$Stream,
 
         [Parameter()]
@@ -127,16 +127,16 @@ function Start-ThreadRun {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Runs/Stop-ThreadRun.ps1
+++ b/Public/Runs/Stop-ThreadRun.ps1
@@ -2,7 +2,7 @@ function Stop-ThreadRun {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateScript({ ([string]$_.id).StartsWith('run_', [StringComparison]::Ordinal) -and ([string]$_.thread_id).StartsWith('thread_', [StringComparison]::Ordinal) })]
         [Alias('Run')]
         [Object]$InputObject,
@@ -14,16 +14,16 @@ function Stop-ThreadRun {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Runs/Submit-ToolOutput.ps1
+++ b/Public/Runs/Submit-ToolOutput.ps1
@@ -2,12 +2,12 @@ function Submit-ToolOutput {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateScript({ ([string]$_.id).StartsWith('run_', [StringComparison]::Ordinal) -and ([string]$_.thread_id).StartsWith('thread_', [StringComparison]::Ordinal) })]
         [Alias('Run')]
         [Object]$InputObject,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [AllowEmptyCollection()]
         [System.Collections.IDictionary[]]$ToolOutput,
 
@@ -25,16 +25,16 @@ function Submit-ToolOutput {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Runs/Wait-ThreadRun.ps1
+++ b/Public/Runs/Wait-ThreadRun.ps1
@@ -2,7 +2,7 @@ function Wait-ThreadRun {
     [CmdletBinding(DefaultParameterSetName = 'StatusForWait')]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateScript({ ([string]$_.id).StartsWith('run_', [StringComparison]::Ordinal) -and ([string]$_.thread_id).StartsWith('thread_', [StringComparison]::Ordinal) })]
         [Alias('Run')]
         [Object]$InputObject,
@@ -14,16 +14,16 @@ function Wait-ThreadRun {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Threads/Add-ThreadMessage.ps1
+++ b/Public/Threads/Add-ThreadMessage.ps1
@@ -2,13 +2,13 @@ function Add-ThreadMessage {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('thread_id')]
         [Alias('Thread')]
         [ValidateScript({ [bool](Get-ThreadIdFromInputObject $_) })]
         [Object]$InputObject,
 
-        [Parameter(Mandatory = $true, Position = 0)]
+        [Parameter(Mandatory, Position = 0)]
         [Alias('Text')]
         [Alias('Content')]
         [ValidateNotNullOrEmpty()]
@@ -33,16 +33,16 @@ function Add-ThreadMessage {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Threads/Get-Thread.ps1
+++ b/Public/Threads/Get-Thread.ps1
@@ -2,7 +2,7 @@ function Get-Thread {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('thread_id')]
         [Alias('Thread')]
         [ValidateScript({ [bool](Get-ThreadIdFromInputObject $_) })]
@@ -15,16 +15,16 @@ function Get-Thread {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]
@@ -34,7 +34,7 @@ function Get-Thread {
         [Alias('OrgId')]
         [string]$Organization,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [switch]$Primitive,
 
         [Parameter()]

--- a/Public/Threads/Get-ThreadMessage.ps1
+++ b/Public/Threads/Get-ThreadMessage.ps1
@@ -2,13 +2,13 @@ function Get-ThreadMessage {
     [CmdletBinding(DefaultParameterSetName = 'List')]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('thread_id')]
         [Alias('Thread')]
         [ValidateScript({ [bool](Get-ThreadIdFromInputObject $_) })]
         [Object]$InputObject,
 
-        [Parameter(ParameterSetName = 'Get', Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'Get', Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('message_id')]
         [ValidateNotNullOrEmpty()]
         [string][UrlEncodeTransformation()]$MessageId,
@@ -20,10 +20,10 @@ function Get-ThreadMessage {
         [Parameter(ParameterSetName = 'ListAll')]
         [switch]$All,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$After,
 
-        [Parameter(ParameterSetName = 'ListAll', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ListAll', DontShow)]
         [string]$Before,
 
         [Parameter(ParameterSetName = 'List')]
@@ -42,16 +42,16 @@ function Get-ThreadMessage {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Threads/New-Thread.ps1
+++ b/Public/Threads/New-Thread.ps1
@@ -3,10 +3,10 @@ function New-Thread {
     [OutputType([pscustomobject])]
     param (
         # Hidden param, for Set-Thread cmdlet
-        [Parameter(DontShow = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(DontShow, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Object]$InputObject,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [object[]]$Messages,
 
         [Parameter()]
@@ -19,16 +19,16 @@ function New-Thread {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Threads/Remove-Thread.ps1
+++ b/Public/Threads/Remove-Thread.ps1
@@ -2,7 +2,7 @@ function Remove-Thread {
     [CmdletBinding()]
     [OutputType([void])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('thread_id')]
         [Alias('Thread')]
         [ValidateScript({ [bool](Get-ThreadIdFromInputObject $_) })]
@@ -15,16 +15,16 @@ function Remove-Thread {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/Public/Threads/Set-Thread.ps1
+++ b/Public/Threads/Set-Thread.ps1
@@ -2,7 +2,7 @@ function Set-Thread {
     [CmdletBinding()]
     [OutputType([pscustomobject])]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [Alias('thread_id')]
         [Alias('Thread')]
         [ValidateScript({ [bool](Get-ThreadIdFromInputObject $_) })]
@@ -18,16 +18,16 @@ function Set-Thread {
         [ValidateRange(0, 100)]
         [int]$MaxRetryCount = 0,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [OpenAIApiType]$ApiType = [OpenAIApiType]::OpenAI,
 
         [Parameter()]
         [System.Uri]$ApiBase,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$ApiVersion,
 
-        [Parameter(DontShow = $true)]
+        [Parameter(DontShow)]
         [string]$AuthType = 'openai',
 
         [Parameter()]

--- a/publish.ps1
+++ b/publish.ps1
@@ -1,7 +1,7 @@
 #Requires -Modules Microsoft.PowerShell.PSResourceGet
 
 Param (
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
     [string]$NugetApiKey,
 


### PR DESCRIPTION
Starting in PowerShell 3.0, " = $true" is no longer required.

Small change, but nicely de-clutters. Optional, of course. Both ways work.