### PR TITLE
Enforce style

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
-    // formatting style this project adheres to: https://en.wikipedia.org/wiki/Indentation_style#Allman
-    "powershell.codeFormatting.preset": "Allman",
-    "powershell.codeFormatting.openBraceOnSameLine": false,
+    // formatting style this project adheres to: https://en.wikipedia.org/wiki/Indentation_style#Stroustrup
+    "powershell.codeFormatting.preset": "Stroustrup",
     "powershell.codeFormatting.useConstantStrings": true,
     "powershell.codeFormatting.useCorrectCasing": true,
     "powershell.codeFormatting.newLineAfterOpenBrace": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,21 +1,23 @@
 {
+    // formatting style this project adheres to: https://en.wikipedia.org/wiki/Indentation_style#Allman
+    "powershell.codeFormatting.preset": "Allman",
+    "powershell.codeFormatting.openBraceOnSameLine": false,
     "powershell.codeFormatting.useConstantStrings": true,
     "powershell.codeFormatting.useCorrectCasing": true,
+    "powershell.codeFormatting.newLineAfterOpenBrace": true,
+    "powershell.codeFormatting.addWhitespaceAroundPipe": true,
+    // editor settings for formatting standards on this project
     "files.trimTrailingWhitespace": true,
     "editor.formatOnSave": true,
-    // formatting style this project adheres to: https://en.wikipedia.org/wiki/Indentation_style?useskin=vector#Allman_style
-    "powershell.codeFormatting.preset": "Allman",
-    // editor settings for formatting standards on this project
     "editor.tabSize": 4,
     "editor.detectIndentation": false,
     "editor.insertSpaces": true,
     // now your double clicks on a variable names include the dollar sign '$'
     // https://twitter.com/TylerLeonhardt/status/1102749805233737729
     "[powershell]": {
-        "editor.wordSeparators": "`~!@#%^&*()-=+[{]}\\|;:'\",.<>/?"
+       "editor.wordSeparators": "`~!@#%^&*()-=+[{]}\\|;:'\",.<>/?"
     },
     "powershell.scriptAnalysis.settingsPath": "PSScriptAnalyzerRules.psd1",
-    "powershell.codeFormatting.addWhitespaceAroundPipe": true,
     "[markdown]": {
         "files.trimTrailingWhitespace": false
     },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,8 @@
     "powershell.codeFormatting.useCorrectCasing": true,
     "files.trimTrailingWhitespace": true,
     "editor.formatOnSave": true,
-    // formatting style this project adheres to: https://en.wikipedia.org/wiki/Indentation_style#Variant:_1TBS_(OTBS)
-    "powershell.codeFormatting.preset": "OTBS",
+    // formatting style this project adheres to: https://en.wikipedia.org/wiki/Indentation_style?useskin=vector#Allman_style
+    "powershell.codeFormatting.preset": "Allman",
     // editor settings for formatting standards on this project
     "editor.tabSize": 4,
     "editor.detectIndentation": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,8 @@
     "powershell.codeFormatting.preset": "Stroustrup",
     "powershell.codeFormatting.useConstantStrings": true,
     "powershell.codeFormatting.useCorrectCasing": true,
-    "powershell.codeFormatting.newLineAfterOpenBrace": true,
     "powershell.codeFormatting.addWhitespaceAroundPipe": true,
+    "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationForFirstPipeline",
     // editor settings for formatting standards on this project
     "files.trimTrailingWhitespace": true,
     "editor.formatOnSave": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,19 @@
     "powershell.codeFormatting.useCorrectCasing": true,
     "files.trimTrailingWhitespace": true,
     "editor.formatOnSave": true,
+    // formatting style this project adheres to: https://en.wikipedia.org/wiki/Indentation_style#Variant:_1TBS_(OTBS)
+    "powershell.codeFormatting.preset": "OTBS",
+    // editor settings for formatting standards on this project
+    "editor.tabSize": 4,
+    "editor.detectIndentation": false,
+    "editor.insertSpaces": true,
+    // now your double clicks on a variable names include the dollar sign '$'
+    // https://twitter.com/TylerLeonhardt/status/1102749805233737729
+    "[powershell]": {
+        "editor.wordSeparators": "`~!@#%^&*()-=+[{]}\\|;:'\",.<>/?"
+    },
+    "powershell.scriptAnalysis.settingsPath": "PSScriptAnalyzerRules.psd1",
+    "powershell.codeFormatting.addWhitespaceAroundPipe": true,
     "[markdown]": {
         "files.trimTrailingWhitespace": false
     },

--- a/PSScriptAnalyzerRules.psd1
+++ b/PSScriptAnalyzerRules.psd1
@@ -3,7 +3,6 @@
     IncludeRules = @(
         'PSUseCompatibleSyntax',
         'PSAvoidUsingCmdletAliases',
-        'PSAvoidUsingWriteHost',
         'PSAvoidDefaultValueSwitchParameter',
         'PSReservedCmdletChar',
         'PSReservedParams',

--- a/PSScriptAnalyzerRules.psd1
+++ b/PSScriptAnalyzerRules.psd1
@@ -31,10 +31,8 @@
         PSUseCompatibleSyntax      = @{
             Enable        = $true
             TargetVersion = @(
-                '3.0',
-                '4.0',
                 '5.1',
-                '6.2'
+                '7.2'
             )
         }
 

--- a/PSScriptAnalyzerRules.psd1
+++ b/PSScriptAnalyzerRules.psd1
@@ -1,0 +1,84 @@
+@{
+    Severity     = @('Error')
+    IncludeRules = @(
+        'PSUseCompatibleSyntax',
+        'PSAvoidUsingCmdletAliases',
+        'PSAvoidUsingWriteHost',
+        'PSAvoidDefaultValueSwitchParameter',
+        'PSReservedCmdletChar',
+        'PSReservedParams',
+        'PSAvoidUsingUserNameAndPassWordParams',
+        'PSAvoidUsingPlaintTextForPassword',
+        'PSAvoidUsingWMICmdlet',
+        'PSAvoidUsingWriteHost',
+        'PSMisleadingBacktick',
+        'PSMissingModuleManifestField',
+        'PSPossibleIncorrectComparisonWithNull',
+        'PSUseApprovedVerbs',
+        'PSUseOutputTypeCorrectly',
+        'PSShouldProcess',
+        'PSUserToExportFieldsInManifest',
+        'PSUseSingularNouns',
+        'PSAvoidUsingInvokeExpression',
+        'PSUseShouldProcessForStateChangingFunctions',
+        'PSUseDeclaredVarsMoreThanAssignments',
+        'PSUseCore',
+        'PSPlaceOpenBrace',
+        'PSPlaceCloseBrace',
+        'PSUseConsistentWhitespace',
+        'PSUseConsistentIndentation',
+        'PSAlignAssignmentStatement'
+        # 'PSUseCorrectCasing' ## We do not like the use of -EQ, prefer -eq
+    )
+    Rules        = @{
+        PSUseCompatibleSyntax      = @{
+            Enable        = $true
+            TargetVersion = @(
+                '3.0',
+                '4.0',
+                '5.1',
+                '6.2'
+            )
+        }
+
+        PSPlaceOpenBrace           = @{
+            Enable             = $true
+            OnSameLine         = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+        }
+
+        PSPlaceCloseBrace          = @{
+            Enable             = $true
+            NewLineAfter       = $false
+            IgnoreOneLineBlock = $true
+            NoEmptyLineBefore  = $false
+        }
+
+        PSUseConsistentIndentation = @{
+            Enable              = $true
+            Kind                = 'space'
+            PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+            IndentationSize     = 4
+        }
+
+        PSUseConsistentWhitespace  = @{
+            Enable          = $true
+            CheckInnerBrace = $true
+            CheckOpenBrace  = $true
+            CheckOpenParen  = $true
+            CheckOperator   = $false
+            CheckPipe       = $true
+            CheckSeparator  = $true
+        }
+
+        PSAlignAssignmentStatement = @{
+            Enable         = $true
+            CheckHashtable = $true
+        }
+
+        PSUseCorrectCasing         = @{
+            Enable = $true
+        }
+    }
+}

--- a/PSScriptAnalyzerRules.psd1
+++ b/PSScriptAnalyzerRules.psd1
@@ -15,7 +15,6 @@
         'PSUseApprovedVerbs',
         'PSUseOutputTypeCorrectly',
         'PSShouldProcess',
-        'PSUserToExportFieldsInManifest',
         'PSUseSingularNouns',
         'PSAvoidUsingInvokeExpression',
         'PSUseDeclaredVarsMoreThanAssignments',

--- a/PSScriptAnalyzerRules.psd1
+++ b/PSScriptAnalyzerRules.psd1
@@ -18,7 +18,6 @@
         'PSUseSingularNouns',
         'PSAvoidUsingInvokeExpression',
         'PSUseDeclaredVarsMoreThanAssignments',
-        'PSUseCore',
         'PSPlaceOpenBrace',
         'PSPlaceCloseBrace',
         'PSUseConsistentWhitespace',

--- a/PSScriptAnalyzerRules.psd1
+++ b/PSScriptAnalyzerRules.psd1
@@ -22,8 +22,8 @@
         'PSPlaceCloseBrace',
         'PSUseConsistentWhitespace',
         'PSUseConsistentIndentation',
-        'PSAlignAssignmentStatement'
-        # 'PSUseCorrectCasing' ## We do not like the use of -EQ, prefer -eq
+        'PSAlignAssignmentStatement',
+        'PSUseCorrectCasing'
     )
     Rules        = @{
         PSUseCompatibleSyntax      = @{

--- a/PSScriptAnalyzerRules.psd1
+++ b/PSScriptAnalyzerRules.psd1
@@ -9,7 +9,6 @@
         'PSAvoidUsingUserNameAndPassWordParams',
         'PSAvoidUsingPlaintTextForPassword',
         'PSAvoidUsingWMICmdlet',
-        'PSAvoidUsingWriteHost',
         'PSMisleadingBacktick',
         'PSMissingModuleManifestField',
         'PSPossibleIncorrectComparisonWithNull',

--- a/PSScriptAnalyzerRules.psd1
+++ b/PSScriptAnalyzerRules.psd1
@@ -45,7 +45,7 @@
 
         PSPlaceCloseBrace          = @{
             Enable             = $true
-            NewLineAfter       = $false
+            NewLineAfter       = $true
             IgnoreOneLineBlock = $true
             NoEmptyLineBefore  = $false
         }

--- a/PSScriptAnalyzerRules.psd1
+++ b/PSScriptAnalyzerRules.psd1
@@ -18,7 +18,6 @@
         'PSUserToExportFieldsInManifest',
         'PSUseSingularNouns',
         'PSAvoidUsingInvokeExpression',
-        'PSUseShouldProcessForStateChangingFunctions',
         'PSUseDeclaredVarsMoreThanAssignments',
         'PSUseCore',
         'PSPlaceOpenBrace',


### PR DESCRIPTION
This is a proposal for style enforcement. As the module grows, more contributors will come and some will like tabs, while others like spaces. This makes the style uniform.

<strike>I chose OTBS only because that's what we use for dbatools. This is entirely your decision, of course, and I'm happy to follow the decided style.</strike>

ChatGPT said you like Allman style: https://en.wikipedia.org/wiki/Indentation_style#Allman_style

I also love editor.wordSeparators. That one ensures that when we click a variable, it includes the $, making copy/paste way easier for PowerShell files.