### PR TITLE
Fix Auth on PS 5.1

### DIFF
--- a/Private/Invoke-OpenAIAPIRequest.ps1
+++ b/Private/Invoke-OpenAIAPIRequest.ps1
@@ -195,7 +195,8 @@ function Invoke-OpenAIAPIRequest {
             $UseBearer = $false
             $RequestHeaders['api-key'] = $PlainToken
         }
-        'azure_ad' {
+        default {
+            # includes azure_ad and null
             $UseBearer = $true
         }
     }

--- a/Private/Invoke-OpenAIAPIRequest.ps1
+++ b/Private/Invoke-OpenAIAPIRequest.ps1
@@ -195,8 +195,11 @@ function Invoke-OpenAIAPIRequest {
             $UseBearer = $false
             $RequestHeaders['api-key'] = $PlainToken
         }
+        'azure_ad' {
+            $UseBearer = $true
+        }
         default {
-            # includes azure_ad and null
+            # covers null
             $UseBearer = $true
         }
     }

--- a/Private/Invoke-OpenAIAPIRequestSSE.ps1
+++ b/Private/Invoke-OpenAIAPIRequestSSE.ps1
@@ -111,7 +111,8 @@ function Invoke-OpenAIAPIRequestSSE {
         'azure' {
             $RequestMessage.Headers.Add('api-key', $PlainToken)
         }
-        'azure_ad' {
+        default {
+            # covers null and azure_ad
             $RequestMessage.Headers.Authorization = [System.Net.Http.Headers.AuthenticationHeaderValue]::new('Bearer', $PlainToken)
         }
     }

--- a/Private/Invoke-OpenAIAPIRequestSSE.ps1
+++ b/Private/Invoke-OpenAIAPIRequestSSE.ps1
@@ -111,8 +111,11 @@ function Invoke-OpenAIAPIRequestSSE {
         'azure' {
             $RequestMessage.Headers.Add('api-key', $PlainToken)
         }
+        'azure_ad' {
+            $RequestMessage.Headers.Authorization = [System.Net.Http.Headers.AuthenticationHeaderValue]::new('Bearer', $PlainToken)
+        }
         default {
-            # covers null and azure_ad
+            # covers null
             $RequestMessage.Headers.Authorization = [System.Net.Http.Headers.AuthenticationHeaderValue]::new('Bearer', $PlainToken)
         }
     }

--- a/Public/Runs/Start-ThreadRun.ps1
+++ b/Public/Runs/Start-ThreadRun.ps1
@@ -185,12 +185,8 @@ function Start-ThreadRun {
             $EndpointName = 'Runs'
         }
 
-        if ($ApiType -eq [OpenAIApiType]::Azure) {
-            $OpenAIParameter = Get-AzureOpenAIAPIEndpoint -EndpointName $EndpointName -ApiBase $ApiBase -ApiVersion $ApiVersion
-        }
-        else {
-            $OpenAIParameter = Get-OpenAIAPIEndpoint -EndpointName $EndpointName -ApiBase $ApiBase
-        }
+        # Get API context
+        $OpenAIParameter = Get-OpenAIContext -EndpointName $EndpointName -ApiType $ApiType -AuthType $AuthType -ApiBase $ApiBase -ApiVersion $ApiVersion -ErrorAction Stop
 
         # Parse Common params
         $CommonParams = ParseCommonParams $PSBoundParameters


### PR DESCRIPTION
Running the example in the Guides for VectorStore worked entirely on Core but only up until the thread run on PS 5.1. Then I'd get:

```
Start-ThreadRun -Stream -Message "how do i get started?" -VectorStoresForFileSearch xyz -MaxCompletionTokens 2048 -Assistant xyz
Invoke-OpenAIAPIRequestSSE : OpenAI API returned an 401 (Unauthorized) Error: Missing bearer or basic authentication
in header
At C:\github\PSOpenAI\Private\Invoke-OpenAIAPIRequest.ps1:150 char:9
+         Invoke-OpenAIAPIRequestSSE @params
```