### PR TITLE
Add-ThreadMessage - Wait for run complete

### DIFF
--- a/Docs/Add-ThreadMessage.md
+++ b/Docs/Add-ThreadMessage.md
@@ -28,6 +28,7 @@ Add-ThreadMessage
     [-ApiKey <SecureString>]
     [-Organization <String>]
     [-PassThru]
+    [-WaitForRunComplete]
     [<CommonParameters>]
 ```
 
@@ -131,6 +132,16 @@ Position: Named
 
 ### -PassThru
 Returns a Thread object that the message added. By default, this cmdlet doesn't generate any output.
+
+```yaml
+Type: SwitchParameter
+Required: False
+Position: Named
+```
+
+### -WaitForRunComplete
+This switch parameter, when used, ensures that the cmdlet waits for any active run on the thread to complete before attempting to add a new message. This can help prevent errors that occur when trying to add messages to a thread while a run is still active.
+This parameter is optional. If not provided, the cmdlet will attempt to add a message to the thread immediately, regardless of whether a run is active or not.
 
 ```yaml
 Type: SwitchParameter

--- a/Public/Threads/Add-ThreadMessage.ps1
+++ b/Public/Threads/Add-ThreadMessage.ps1
@@ -71,6 +71,9 @@ function Add-ThreadMessage {
         [switch]$PassThru,
 
         [Parameter()]
+        [switch]$WaitForRunComplete,
+
+        [Parameter()]
         [System.Collections.IDictionary]$AdditionalQuery,
 
         [Parameter()]
@@ -208,17 +211,11 @@ function Add-ThreadMessage {
         #endregion
 
         #region Wait for good time to send API request
-        $runs = Get-ThreadRun -ThreadId $ThreadId -All
-        foreach ($run in $runs) {
-            $waitTime = 0
-            $run = Get-ThreadRun -ThreadId $ThreadId -RunId $run.id
-            while ($run.status -in 'queued', 'in_progress', 'requires_action' -and $waitTime -le 5) {
-                Start-Sleep -Seconds 1
-                $waitTime++
-                $run = Get-ThreadRun -ThreadId $ThreadId -RunId $run.id
-            }
-            if ($run.status -in 'queued', 'in_progress', 'requires_action') {
-                $null = Stop-ThreadRun -ThreadId $ThreadId -RunId $run.id
+        if ($WaitForRunComplete) {
+            $runs = Get-ThreadRun -ThreadId $ThreadId -All
+            foreach ($run in $runs) {
+                Write-Host "Waiting for the run to complete. Run ID: $($run.id)"
+                Wait-ThreadRun -Run $run @CommonParams
             }
         }
         #endregion

--- a/Public/Threads/Add-ThreadMessage.ps1
+++ b/Public/Threads/Add-ThreadMessage.ps1
@@ -208,19 +208,17 @@ function Add-ThreadMessage {
         #endregion
 
         #region Wait for good time to send API request
-        $waitTime = 0
-        $run = Get-ThreadRun -ThreadId $ThreadId -All
-        if ($run.status) {
-            while ($run.status -ne 'completed' -and $waitTime -le 5) {
+        $runs = Get-ThreadRun -ThreadId $ThreadId -All
+        foreach ($run in $runs) {
+            $waitTime = 0
+            $run = Get-Run -ThreadId $ThreadId -RunId $run.id
+            while ($run.status -in 'queued', 'in_progress', 'requires_action' -and $waitTime -le 5) {
                 Start-Sleep -Seconds 1
                 $waitTime++
-                $run = Get-Run -ThreadId $ThreadID -All
+                $run = Get-Run -ThreadId $ThreadId -RunId $run.id
             }
-
-            if ($run.status -ne 'completed') {
-                foreach ($runid in $run.id) {
-                    $null = Stop-ThreadRun -ThreadId $ThreadID -RunId $runid
-                }
+            if ($run.status -in 'queued', 'in_progress', 'requires_action') {
+                $null = Stop-ThreadRun -ThreadId $ThreadId -RunId $run.id
             }
         }
         #endregion

--- a/Public/Threads/Add-ThreadMessage.ps1
+++ b/Public/Threads/Add-ThreadMessage.ps1
@@ -207,6 +207,24 @@ function Add-ThreadMessage {
         }
         #endregion
 
+        #region Wait for good time to send API request
+        $waitTime = 0
+        $run = Get-ThreadRun -ThreadId $ThreadId -All
+        if ($run.status) {
+            while ($run.status -ne 'completed' -and $waitTime -le 5) {
+                Start-Sleep -Seconds 1
+                $waitTime++
+                $run = Get-Run -ThreadId $ThreadID -All
+            }
+
+            if ($run.status -ne 'completed') {
+                foreach ($runid in $run.id) {
+                    $null = Stop-ThreadRun -ThreadId $ThreadID -RunId $runid
+                }
+            }
+        }
+        #endregion
+
         #region Send API Request
         $params = @{
             Method            = $OpenAIParameter.Method

--- a/Public/Threads/Add-ThreadMessage.ps1
+++ b/Public/Threads/Add-ThreadMessage.ps1
@@ -214,7 +214,7 @@ function Add-ThreadMessage {
         if ($WaitForRunComplete) {
             $runs = Get-ThreadRun -ThreadId $ThreadId -All
             foreach ($run in $runs) {
-                Write-Host "Waiting for the run to complete. Run ID: $($run.id)"
+                Write-Verbose "Waiting for the run to complete. Run ID: $($run.id)"
                 Wait-ThreadRun -Run $run @CommonParams
             }
         }

--- a/Public/Threads/Add-ThreadMessage.ps1
+++ b/Public/Threads/Add-ThreadMessage.ps1
@@ -215,7 +215,7 @@ function Add-ThreadMessage {
             $runs = Get-ThreadRun -ThreadId $ThreadId -All
             foreach ($run in $runs) {
                 Write-Verbose "Waiting for the run to complete. Run ID: $($run.id)"
-                Wait-ThreadRun -Run $run @CommonParams
+                $null = Wait-ThreadRun -Run $run @CommonParams
             }
         }
         #endregion

--- a/Public/Threads/Add-ThreadMessage.ps1
+++ b/Public/Threads/Add-ThreadMessage.ps1
@@ -211,11 +211,11 @@ function Add-ThreadMessage {
         $runs = Get-ThreadRun -ThreadId $ThreadId -All
         foreach ($run in $runs) {
             $waitTime = 0
-            $run = Get-Run -ThreadId $ThreadId -RunId $run.id
+            $run = Get-ThreadRun -ThreadId $ThreadId -RunId $run.id
             while ($run.status -in 'queued', 'in_progress', 'requires_action' -and $waitTime -le 5) {
                 Start-Sleep -Seconds 1
                 $waitTime++
-                $run = Get-Run -ThreadId $ThreadId -RunId $run.id
+                $run = Get-ThreadRun -ThreadId $ThreadId -RunId $run.id
             }
             if ($run.status -in 'queued', 'in_progress', 'requires_action') {
                 $null = Stop-ThreadRun -ThreadId $ThreadId -RunId $run.id


### PR DESCRIPTION
To handle this error I encountered when reusing threads

```
OpenAI API returned an 400 (BadRequest) Error: Cant add messages to
thread_abc while a run run_xyz is active.
At C:\github\psopenai\Public\Threads\Add-ThreadMessage.ps1:149 char:21
+         $Response = Invoke-OpenAIAPIRequest @params
```

Edit: need to fix to account for more

![image](https://github.com/mkht/PSOpenAI/assets/8278033/490b0040-8ffe-4d69-8efd-40e716f7f766)

k, done!