### PR TITLE
Azure - Add default deployment model

### DIFF
--- a/PSOpenAI.psm1
+++ b/PSOpenAI.psm1
@@ -1,4 +1,5 @@
 
+$script:DefaultDeploymentModel = 'gpt-3.5-turbo'
 $PrivateDirectory = Join-Path $PSScriptRoot 'Private'
 $PublicDirectory = Join-Path $PSScriptRoot 'Public'
 

--- a/Public/Assistants/New-Assistant.ps1
+++ b/Public/Assistants/New-Assistant.ps1
@@ -30,7 +30,7 @@ function New-Assistant {
             'gpt-4-turbo',
             'gpt-4-turbo-2024-04-09'
         )]
-        [string][LowerCaseTransformation()]$Model = 'gpt-3.5-turbo',
+        [string][LowerCaseTransformation()]$Model = $script:DefaultDeploymentModel,
 
         [Parameter()]
         [ValidateLength(0, 512)]

--- a/Public/Assistants/Set-Assistant.ps1
+++ b/Public/Assistants/Set-Assistant.ps1
@@ -31,7 +31,7 @@ function Set-Assistant {
             'gpt-4-turbo',
             'gpt-4-turbo-2024-04-09'
         )]
-        [string][LowerCaseTransformation()]$Model = 'gpt-3.5-turbo',
+        [string][LowerCaseTransformation()]$Model = $script:DefaultDeploymentModel,
 
         [Parameter()]
         [ValidateLength(0, 512)]

--- a/Public/Azure/Assistants/New-AzureAssistant.ps1
+++ b/Public/Azure/Assistants/New-AzureAssistant.ps1
@@ -16,7 +16,7 @@ function New-AzureAssistant {
 
         [Parameter(Mandatory)]
         [Alias('Model')]
-        [string]$Deployment,
+        [string]$Deployment = $script:DefaultDeploymentModel,
 
         [Parameter()]
         [ValidateLength(0, 512)]

--- a/Public/Azure/Assistants/Set-AzureAssistant.ps1
+++ b/Public/Azure/Assistants/Set-AzureAssistant.ps1
@@ -17,7 +17,7 @@ function Set-AzureAssistant {
 
         [Parameter()]
         [Alias('Model')]
-        [string]$Deployment,
+        [string]$Deployment = $script:DefaultDeploymentModel,
 
         [Parameter()]
         [ValidateLength(0, 512)]

--- a/Public/Azure/Request-AzureAudioSpeech.ps1
+++ b/Public/Azure/Request-AzureAudioSpeech.ps1
@@ -14,7 +14,7 @@ function Request-AzureAudioSpeech {
 
         [Parameter(Mandatory)]
         [Alias('Model')]
-        [string]$Deployment,
+        [string]$Deployment = $script:DefaultDeploymentModel,
 
         [Parameter()]
         [Completions(

--- a/Public/Azure/Request-AzureAudioTranscription.ps1
+++ b/Public/Azure/Request-AzureAudioTranscription.ps1
@@ -8,7 +8,7 @@ function Request-AzureAudioTranscription {
 
         [Parameter(Mandatory)]
         [Alias('Model')]
-        [string]$Deployment,
+        [string]$Deployment = $script:DefaultDeploymentModel,
 
         [Parameter()]
         [string]$Prompt,

--- a/Public/Azure/Request-AzureAudioTranslation.ps1
+++ b/Public/Azure/Request-AzureAudioTranslation.ps1
@@ -8,7 +8,7 @@ function Request-AzureAudioTranslation {
 
         [Parameter(Mandatory)]
         [Alias('Model')]
-        [string]$Deployment,
+        [string]$Deployment = $script:DefaultDeploymentModel,
 
         [Parameter()]
         [string]$Prompt,

--- a/Public/Azure/Request-AzureChatCompletion.ps1
+++ b/Public/Azure/Request-AzureChatCompletion.ps1
@@ -19,7 +19,7 @@ function Request-AzureChatCompletion {
 
         [Parameter(Mandatory)]
         [Alias('Model')]
-        [string]$Deployment,
+        [string]$Deployment = $script:DefaultDeploymentModel,
 
         [Parameter()]
         [AllowEmptyString()]

--- a/Public/Azure/Request-AzureEmbeddings.ps1
+++ b/Public/Azure/Request-AzureEmbeddings.ps1
@@ -14,7 +14,7 @@ function Request-AzureEmbeddings {
 
         [Parameter(Mandatory)]
         [Alias('Model')]
-        [string]$Deployment,
+        [string]$Deployment = $script:DefaultDeploymentModel,
 
         [Parameter()]
         [Alias('encoding_format')]

--- a/Public/Azure/Request-AzureImageGeneration.ps1
+++ b/Public/Azure/Request-AzureImageGeneration.ps1
@@ -8,7 +8,7 @@ function Request-AzureImageGeneration {
         [Parameter(Mandatory = $false)]
         [Alias('Model')]
         [ValidateNotNullOrEmpty()]
-        [string]$Deployment,
+        [string]$Deployment = $script:DefaultDeploymentModel,
 
         [Parameter()]
         [ValidateRange(1, 5)]

--- a/Public/Azure/Request-AzureTextCompletion.ps1
+++ b/Public/Azure/Request-AzureTextCompletion.ps1
@@ -12,7 +12,7 @@ function Request-AzureTextCompletion {
 
         [Parameter(Mandatory)]
         [Alias('Model')]
-        [string]$Deployment,
+        [string]$Deployment = $script:DefaultDeploymentModel,
 
         [Parameter()]
         [ValidateRange(0.0, 2.0)]

--- a/Public/Azure/Runs/Start-AzureThreadRun.ps1
+++ b/Public/Azure/Runs/Start-AzureThreadRun.ps1
@@ -19,7 +19,7 @@ function Start-AzureThreadRun {
 
         [Parameter()]
         [Alias('Model')]
-        [string]$Deployment,
+        [string]$Deployment = $script:DefaultDeploymentModel,
 
         [Parameter()]
         [ValidateLength(0, 32768)]

--- a/Public/Request-ChatCompletion.ps1
+++ b/Public/Request-ChatCompletion.ps1
@@ -33,7 +33,7 @@ function Request-ChatCompletion {
             'gpt-4-turbo',
             'gpt-4-turbo-2024-04-09'
         )]
-        [string][LowerCaseTransformation()]$Model = 'gpt-3.5-turbo',
+        [string][LowerCaseTransformation()]$Model = $script:DefaultDeploymentModel,
 
         [Parameter()]
         [AllowEmptyString()]

--- a/Public/Runs/Start-ThreadRun.ps1
+++ b/Public/Runs/Start-ThreadRun.ps1
@@ -33,7 +33,7 @@ function Start-ThreadRun {
             'gpt-4-turbo',
             'gpt-4-turbo-2024-04-09'
         )]
-        [string][LowerCaseTransformation()]$Model = 'gpt-3.5-turbo',
+        [string][LowerCaseTransformation()]$Model = $script:DefaultDeploymentModel,
 
         [Parameter()]
         [ValidateLength(0, 256000)]

--- a/Public/Set-OpenAIContext.ps1
+++ b/Public/Set-OpenAIContext.ps1
@@ -19,6 +19,10 @@ function Set-OpenAIContext {
         [string]$AuthType = 'openai',
 
         [Parameter(ValueFromPipelineByPropertyName)]
+        [Alias('DeploymentName')]
+        [string]$Deployment,
+
+        [Parameter(ValueFromPipelineByPropertyName)]
         [Alias('OrgId')]
         [string]$Organization,
 
@@ -59,6 +63,9 @@ function Set-OpenAIContext {
         $Global:PSOpenAIContextDictionary['ApiType'] -eq [OpenAIApiType]::OpenAI
     ) {
         $Global:PSOpenAIContextDictionary['AuthType'] = 'openai'
+    }
+    if ($PSBoundParameters.ContainsKey('Deployment')) {
+        $script:DefaultDeploymentModel = $Deployment
     }
     if ($PSBoundParameters.ContainsKey('Organization')) {
         $Global:PSOpenAIContextDictionary['Organization'] = $Organization


### PR DESCRIPTION
This makes it easier to do

```
$azparms = @{
    ApiType    = 'azure'
    ApiKey     = 'xyz'
    ApiBase    = 'https://xyz.openai.azure.com'
    Deployment = 'gpt4'
}
Set-OpenAIContext @azparms

Request-ChatCompletion -Message 'Hello Azure OpenAI'
```

Instead of a mix of $DeploymentName and Set-OpenAIContext.