### PR TITLE
Update Azure OpenAI Guide

### DIFF
--- a/Guides/How_to_use_with_Azure_OpenAI_Service.ipynb
+++ b/Guides/How_to_use_with_Azure_OpenAI_Service.ipynb
@@ -209,7 +209,7 @@
                 "Request-ChatCompletion `\n",
                 "  -ApiType Azure `  # This parameter switches to the Azure API.\n",
                 "  -Message 'Hello Azure OpenAI Service.' `\n",
-                "  -Deployment $DeploymentName `\n",
+                "  -Model $DeploymentName `\n",
                 "  -AuthType $AuthType"
             ]
         }


### PR DESCRIPTION
Typo in the guide, the -Deployment parameter doesn't exist anymore, it's -Model

