### PR TITLE
Request-ChatCompletion - Set ConvertFrom-Json params for PS 7.x

### DIFF
--- a/Public/Request-ChatCompletion.ps1
+++ b/Public/Request-ChatCompletion.ps1
@@ -194,6 +194,10 @@ function Request-ChatCompletion {
         else {
             $Engine = $Model
         }
+
+        # Set params for PS 7.x while still supporting 5.1
+        $PSDefaultParameterValues['ConvertFrom-Json:Depth'] = 64
+        $PSDefaultParameterValues['ConvertFrom-Json:NoEnumerate'] = $true
     }
 
     process {


### PR DESCRIPTION
Request-ChatCompletion - Set ConvertFrom-Json params for PS 7.x while still supporting 5.1

Fixes https://github.com/mkht/PSOpenAI/issues/30 while keeping original intent