### PR TITLE
Fix comment typo in Request-ChatCompletion

### DIFF
--- a/Public/Chat/Request-ChatCompletion.ps1
+++ b/Public/Chat/Request-ChatCompletion.ps1
@@ -288,7 +288,7 @@ function Request-ChatCompletion {
         }
         #endregion
 
-        #region Tools paramter validation
+        #region Tools parameter validation
         if ($PSBoundParameters.ContainsKey('Tools')) {
             $tmpTools = [System.Collections.IDictionary[]]::new($Tools.Count)
             for ($i = 0; $i -lt $Tools.Count; $i++) {


### PR DESCRIPTION
## Summary
- fix a small typo in Request-ChatCompletion.ps1 comment

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester -Output Detailed -Tag Offline"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684186f4624883258705614c2b7e080e