### PR TITLE
Fix silence duration parameter check

### DIFF
--- a/Public/Realtime/Set-RealtimeSessionConfiguration.ps1
+++ b/Public/Realtime/Set-RealtimeSessionConfiguration.ps1
@@ -182,7 +182,7 @@ function Set-RealtimeSessionConfiguration {
                 if ($PSBoundParameters.ContainsKey('TurnDetectionPrefixPadding')) {
                     $MessageObject.session.turn_detection.prefix_padding_ms = $TurnDetectionPrefixPadding
                 }
-                if ($PSBoundParameters.ContainsKey('TurnDetectionThreshold')) {
+                if ($PSBoundParameters.ContainsKey('TurnDetectionSilenceDuration')) {
                     $MessageObject.session.turn_detection.silence_duration_ms = $TurnDetectionSilenceDuration
                 }
                 if ($PSBoundParameters.ContainsKey('CreateResponseOnTurnEnd')) {


### PR DESCRIPTION
## Summary
- ensure the turn detection silence duration only sets silence duration when the parameter is specified

## Testing
- `Invoke-ScriptAnalyzer -Settings ./PSScriptAnalyzerRules.psd1 -Path ./Public/Realtime/Set-RealtimeSessionConfiguration.ps1`
- `Invoke-Pester -Tag Offilne`

------
https://chatgpt.com/codex/tasks/task_e_6841a246d5c4832590b3ccb4577f7fdf