### PR TITLE
Add video generation guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 ### 4.40.0
 - Add new models that was announced at OpenAI DevDay 2025.
   + `sora-2`, `sora-2-pro`, `gpt-5-pro`, `gpt-audio`, `gpt-audio-mini`, `gpt-image-1-mini`, `gpt-realtime`, `gpt-realtime-mini`
-- Add New functions for Video generation.
+- Add New functions for Video generation.  
+  Guide: [How to use Video generation](/Guides/How_to_use_Video_generation.md)
     + [New-Video](/Docs/New-Video.md)
     + [New-VideoRemix](/Docs/New-VideoRemix.md)
     + [Get-Video](/Docs/Get-Video.md)

--- a/Guides/How_to_use_Video_generation.md
+++ b/Guides/How_to_use_Video_generation.md
@@ -1,25 +1,22 @@
-# How to use Video generation functions
+# How to use Video generation
 
-Powerful video models such as `sora-2` are available through PSOpenAI. These cmdlets let you request new clips, monitor their progress, download finished assets, remix existing videos, and clean up jobs when you are done.
+Powerful video generation models such as `sora-2` are available through PSOpenAI. These cmdlets let you request new clips, monitor their progress, download finished assets, remix existing videos, and clean up jobs when you are done.
 
-OpenAI's official documentation for videos is here.
-https://platform.openai.com/docs/guides/video_generation
+OpenAI's official documentation for videos is here.  
+https://platform.openai.com/docs/guides/video-generation
 
 This guide shows end-to-end workflows and reusable snippets for each video-related cmdlet.
 
-> [!NOTE]
-> Video generation jobs are asynchronous. The cmdlet that creates or updates a job returns immediately with metadata. Use `Get-Video`, `Wait-Video`, or `Get-VideoContent -WaitForCompletion` to monitor completion before you try to download assets.
 
 ## Functions overview
 
-| Scenario | Cmdlet | What it does |
-| --- | --- | --- |
-| Create a new job | `New-Video` | Submits a prompt, model, duration, and resolution to start rendering.【F:Docs/New-Video.md†L16-L60】 |
-| Inspect job metadata | `Get-Video` | Retrieves a single job or lists recent jobs.【F:Docs/Get-Video.md†L16-L64】 |
-| Wait for completion | `Wait-Video` | Polls a job until it finishes and shows progress in the console.【F:Public/Videos/Wait-Video.ps1†L1-L118】 |
-| Download assets | `Get-VideoContent` | Fetches the rendered video, thumbnail, or spritesheet, optionally waiting for success.【F:Docs/Get-VideoContent.md†L16-L70】 |
-| Remix an existing clip | `New-VideoRemix` | Applies a new prompt to a finished video to regenerate only the requested changes.【F:Docs/New-VideoRemix.md†L10-L47】 |
-| Delete a job | `Remove-Video` | Removes a job you no longer need.【F:Docs/Remove-Video.md†L16-L55】 |
+| Scenario               | Cmdlet             | What it does                                                                           |
+| ---------------------- | ------------------ | -------------------------------------------------------------------------------------- |
+| Create a new job       | `New-Video`        | Submits a prompt, model, duration, and resolution to start rendering.                  |
+| Retrieve job status    | `Get-Video`        | Retrieves a single job or lists jobs.                                                  |
+| Download assets        | `Get-VideoContent` | Fetches the generated video, thumbnail, or spritesheet.                                |
+| Remix an existing clip | `New-VideoRemix`   | Applies a new prompt to a existing video without regenerating everything from scratch. |
+| Delete a job           | `Remove-Video`     | Removes a job you no longer need.                                                      |
 
 ## Prerequisites
 
@@ -28,90 +25,57 @@ This guide shows end-to-end workflows and reusable snippets for each video-relat
    Import-Module ..\PSOpenAI.psd1 -Force
    $env:OPENAI_API_KEY = '<Put your API key here>'
    ```
-2. (Optional) Switch to Azure OpenAI by supplying `-ApiType`, `-ApiBase`, and `-ApiVersion` on each cmdlet.
-3. Have a writable folder ready for downloaded media.
 
 ## Generate and download a video
 
 The script below creates a four-second vertical clip, waits until it finishes, and writes the MP4 to disk.
 
 ```powershell
-# Submit a new job.
-$job = New-Video `
+# Start a new video generation job.
+$VideoJob = New-Video `
     -Prompt 'A hummingbird drinking nectar in super slow motion, macro lens.' `
     -Model 'sora-2' `
     -Seconds 4 `
     -Size 720x1280
 
-# Wait for completion with a progress bar.
-$finishedJob = $job | Wait-Video -PollIntervalSec 5
-
-if ($finishedJob.status -ne 'completed' -and $finishedJob.status -ne 'succeeded') {
-    throw "Job $($finishedJob.id) did not finish successfully."
-}
-
-# Download the rendered clip.
-$videoPath = Join-Path $PWD 'hummingbird.mp4'
-$finishedJob | Get-VideoContent -Variant video -OutFile $videoPath
-```
-
-Key points:
-
-- `New-Video` accepts optional `-Seconds` and `-Size` switches to tune runtime and resolution.【F:Docs/New-Video.md†L22-L60】
-- `Wait-Video` reads the job ID from the pipeline and keeps polling until it leaves the pending statuses.【F:Public/Videos/Wait-Video.ps1†L6-L83】
-- `Get-VideoContent` downloads either the main video (`video`), a `thumbnail`, or a `spritesheet` sprite atlas.【F:Docs/Get-VideoContent.md†L28-L56】
-
-## Poll jobs manually
-
-If you prefer to build your own loop, use `Get-Video` to query job state.
-
-```powershell
-$job = New-Video -Prompt 'An orange tabby cat playing a grand piano on a stage' -Seconds 8 -Size 1280x720
-
+# Wait for completion.
 while ($true) {
-    Start-Sleep -Seconds 6
-    $current = Get-Video -VideoId $job.id
+    Start-Sleep -Seconds 5
+    $current = Get-Video -VideoId $VideoJob.id
     "[{0}] status = {1}, progress = {2}%" -f (Get-Date), $current.status, $current.progress
-
-    if ($current.status -notin @('queued', 'in_progress', 'running', 'processing', 'preprocessing')) {
-        break
-    }
+    if ($current.status -in @('completed', 'failed')) { break }
 }
+
+# Download the generated video.
+$videoPath = Join-Path $PWD 'hummingbird.mp4'
+Get-VideoContent -VideoId $VideoJob.id -OutFile $videoPath
 ```
 
-The job metadata includes `status`, `created_at`, `model`, and a `generations` collection you can inspect or pipe into other cmdlets.【F:Docs/Get-Video.md†L30-L63】
+Above example uses `New-Video` to start a job, then waits until the job completes by polling `Get-Video` every five seconds. Finally, it downloads the MP4 file with `Get-VideoContent`.
 
-## Download assets when ready
-
-`Get-VideoContent` can wait for completion and return bytes in memory when you do not want to touch disk.
+More simply, you can use `-WaitForCompletion` on `Get-VideoContent` to block until the job finishes and download the file in one step.
 
 ```powershell
-$job = New-Video -Prompt 'A drone flythrough of a futuristic city at sunset'
-
-# Wait and download the thumbnail to disk.
-Get-VideoContent -VideoId $job.id -Variant thumbnail -WaitForCompletion -OutFile (Join-Path $PWD 'city.webp')
-
-# Fetch the spritesheet into memory for further processing.
-$spritesheetBytes = Get-VideoContent -VideoId $job.id -Variant spritesheet -WaitForCompletion
+New-Video -Model 'sora-2' -Prompt 'A cat flying with butterfly wings' -Seconds 4 -Size 1280x720 | `
+    Get-VideoContent -OutFile (Join-Path $PWD 'flying_cat.mp4') -WaitForCompletion
 ```
-
-When you omit `-OutFile`, the cmdlet returns a `byte[]` you can stream into other commands or write manually.【F:Docs/Get-VideoContent.md†L34-L53】 Using `-WaitForCompletion` ensures the download starts only after the job succeeds.【F:Docs/Get-VideoContent.md†L20-L33】
 
 ## Remix an existing video
 
 Once you have a completed job, apply targeted changes with `New-VideoRemix`.
 
 ```powershell
-$sourceJob = Get-Video -Limit 1 -Order desc | Select-Object -First 1
+# Assume you have a completed video job with ID 'video_abc123'.
+$sourceJob = Get-Video -VideoId 'video_abc123'
 
-$remix = New-VideoRemix `
+$remixJob = New-VideoRemix `
     -VideoId $sourceJob.id `
     -Prompt 'Replace the background with a vibrant cherry blossom garden, keep the subject intact.'
 
-$remix | Wait-Video | Get-VideoContent -OutFile (Join-Path $PWD 'cherry_blossom_remix.mp4')
+$remixJob | Get-VideoContent -OutFile (Join-Path $PWD 'cherry_blossom_remix.mp4') -WaitForCompletion
 ```
 
-`New-VideoRemix` takes both the prompt and the source `VideoId`, so you can keep the structure of the original clip while updating specific elements.【F:Docs/New-VideoRemix.md†L16-L47】 The resulting job behaves like any other video job—you can wait on it and download content the same way.
+`New-VideoRemix` takes both the prompt and the source `VideoId`, so you can keep the structure of the original clip while updating specific elements. The resulting job behaves like any other video job, you can wait on it and download content the same way.
 
 ## List and clean up jobs
 
@@ -120,18 +84,12 @@ Use the list parameter set on `Get-Video` to review existing jobs and `Remove-Vi
 ```powershell
 # Show the 5 most recent jobs.
 Get-Video -Limit 5 -Order desc |
-    Select-Object id, status, model, seconds, size, created_at
+  Select-Object id, status, created_at, expires_at
 
-# Delete jobs that have already succeeded.
+# Delete all jobs that have already expired.
 Get-Video -All |
-    Where-Object status -in @('completed', 'succeeded') |
-    ForEach-Object { $_ | Remove-Video }
+  Where-Object expires_at -le (Get-Date) |
+    Remove-Video
 ```
 
-`Get-Video -All` automatically pages until every job is returned.【F:Docs/Get-Video.md†L40-L63】 `Remove-Video` accepts IDs from the pipeline so you can compose cleanup flows easily.【F:Docs/Remove-Video.md†L16-L46】
-
-## Troubleshooting tips
-
-- `New-Video` retries are disabled by default. Supply `-MaxRetryCount` if you expect occasional 429 or 5xx responses.【F:Docs/New-Video.md†L61-L96】
-- If you see a timeout while waiting, pass a larger `-TimeoutSec` to `Wait-Video` or `Get-VideoContent`.
-- Always verify the final `status` property (`completed` or `succeeded`) before assuming the media is usable.
+`Remove-Video` accepts IDs from the pipeline so you can compose cleanup flows easily.

--- a/Guides/How_to_use_Video_generation.md
+++ b/Guides/How_to_use_Video_generation.md
@@ -1,0 +1,137 @@
+# How to use Video generation functions
+
+Powerful video models such as `sora-2` are available through PSOpenAI. These cmdlets let you request new clips, monitor their progress, download finished assets, remix existing videos, and clean up jobs when you are done.
+
+OpenAI's official documentation for videos is here.
+https://platform.openai.com/docs/guides/video_generation
+
+This guide shows end-to-end workflows and reusable snippets for each video-related cmdlet.
+
+> [!NOTE]
+> Video generation jobs are asynchronous. The cmdlet that creates or updates a job returns immediately with metadata. Use `Get-Video`, `Wait-Video`, or `Get-VideoContent -WaitForCompletion` to monitor completion before you try to download assets.
+
+## Functions overview
+
+| Scenario | Cmdlet | What it does |
+| --- | --- | --- |
+| Create a new job | `New-Video` | Submits a prompt, model, duration, and resolution to start rendering.【F:Docs/New-Video.md†L16-L60】 |
+| Inspect job metadata | `Get-Video` | Retrieves a single job or lists recent jobs.【F:Docs/Get-Video.md†L16-L64】 |
+| Wait for completion | `Wait-Video` | Polls a job until it finishes and shows progress in the console.【F:Public/Videos/Wait-Video.ps1†L1-L118】 |
+| Download assets | `Get-VideoContent` | Fetches the rendered video, thumbnail, or spritesheet, optionally waiting for success.【F:Docs/Get-VideoContent.md†L16-L70】 |
+| Remix an existing clip | `New-VideoRemix` | Applies a new prompt to a finished video to regenerate only the requested changes.【F:Docs/New-VideoRemix.md†L10-L47】 |
+| Delete a job | `Remove-Video` | Removes a job you no longer need.【F:Docs/Remove-Video.md†L16-L55】 |
+
+## Prerequisites
+
+1. Import the module and set your API key.
+   ```powershell
+   Import-Module ..\PSOpenAI.psd1 -Force
+   $env:OPENAI_API_KEY = '<Put your API key here>'
+   ```
+2. (Optional) Switch to Azure OpenAI by supplying `-ApiType`, `-ApiBase`, and `-ApiVersion` on each cmdlet.
+3. Have a writable folder ready for downloaded media.
+
+## Generate and download a video
+
+The script below creates a four-second vertical clip, waits until it finishes, and writes the MP4 to disk.
+
+```powershell
+# Submit a new job.
+$job = New-Video `
+    -Prompt 'A hummingbird drinking nectar in super slow motion, macro lens.' `
+    -Model 'sora-2' `
+    -Seconds 4 `
+    -Size 720x1280
+
+# Wait for completion with a progress bar.
+$finishedJob = $job | Wait-Video -PollIntervalSec 5
+
+if ($finishedJob.status -ne 'completed' -and $finishedJob.status -ne 'succeeded') {
+    throw "Job $($finishedJob.id) did not finish successfully."
+}
+
+# Download the rendered clip.
+$videoPath = Join-Path $PWD 'hummingbird.mp4'
+$finishedJob | Get-VideoContent -Variant video -OutFile $videoPath
+```
+
+Key points:
+
+- `New-Video` accepts optional `-Seconds` and `-Size` switches to tune runtime and resolution.【F:Docs/New-Video.md†L22-L60】
+- `Wait-Video` reads the job ID from the pipeline and keeps polling until it leaves the pending statuses.【F:Public/Videos/Wait-Video.ps1†L6-L83】
+- `Get-VideoContent` downloads either the main video (`video`), a `thumbnail`, or a `spritesheet` sprite atlas.【F:Docs/Get-VideoContent.md†L28-L56】
+
+## Poll jobs manually
+
+If you prefer to build your own loop, use `Get-Video` to query job state.
+
+```powershell
+$job = New-Video -Prompt 'An orange tabby cat playing a grand piano on a stage' -Seconds 8 -Size 1280x720
+
+while ($true) {
+    Start-Sleep -Seconds 6
+    $current = Get-Video -VideoId $job.id
+    "[{0}] status = {1}, progress = {2}%" -f (Get-Date), $current.status, $current.progress
+
+    if ($current.status -notin @('queued', 'in_progress', 'running', 'processing', 'preprocessing')) {
+        break
+    }
+}
+```
+
+The job metadata includes `status`, `created_at`, `model`, and a `generations` collection you can inspect or pipe into other cmdlets.【F:Docs/Get-Video.md†L30-L63】
+
+## Download assets when ready
+
+`Get-VideoContent` can wait for completion and return bytes in memory when you do not want to touch disk.
+
+```powershell
+$job = New-Video -Prompt 'A drone flythrough of a futuristic city at sunset'
+
+# Wait and download the thumbnail to disk.
+Get-VideoContent -VideoId $job.id -Variant thumbnail -WaitForCompletion -OutFile (Join-Path $PWD 'city.webp')
+
+# Fetch the spritesheet into memory for further processing.
+$spritesheetBytes = Get-VideoContent -VideoId $job.id -Variant spritesheet -WaitForCompletion
+```
+
+When you omit `-OutFile`, the cmdlet returns a `byte[]` you can stream into other commands or write manually.【F:Docs/Get-VideoContent.md†L34-L53】 Using `-WaitForCompletion` ensures the download starts only after the job succeeds.【F:Docs/Get-VideoContent.md†L20-L33】
+
+## Remix an existing video
+
+Once you have a completed job, apply targeted changes with `New-VideoRemix`.
+
+```powershell
+$sourceJob = Get-Video -Limit 1 -Order desc | Select-Object -First 1
+
+$remix = New-VideoRemix `
+    -VideoId $sourceJob.id `
+    -Prompt 'Replace the background with a vibrant cherry blossom garden, keep the subject intact.'
+
+$remix | Wait-Video | Get-VideoContent -OutFile (Join-Path $PWD 'cherry_blossom_remix.mp4')
+```
+
+`New-VideoRemix` takes both the prompt and the source `VideoId`, so you can keep the structure of the original clip while updating specific elements.【F:Docs/New-VideoRemix.md†L16-L47】 The resulting job behaves like any other video job—you can wait on it and download content the same way.
+
+## List and clean up jobs
+
+Use the list parameter set on `Get-Video` to review existing jobs and `Remove-Video` to delete ones you no longer need.
+
+```powershell
+# Show the 5 most recent jobs.
+Get-Video -Limit 5 -Order desc |
+    Select-Object id, status, model, seconds, size, created_at
+
+# Delete jobs that have already succeeded.
+Get-Video -All |
+    Where-Object status -in @('completed', 'succeeded') |
+    ForEach-Object { $_ | Remove-Video }
+```
+
+`Get-Video -All` automatically pages until every job is returned.【F:Docs/Get-Video.md†L40-L63】 `Remove-Video` accepts IDs from the pipeline so you can compose cleanup flows easily.【F:Docs/Remove-Video.md†L16-L46】
+
+## Troubleshooting tips
+
+- `New-Video` retries are disabled by default. Supply `-MaxRetryCount` if you expect occasional 429 or 5xx responses.【F:Docs/New-Video.md†L61-L96】
+- If you see a timeout while waiting, pass a larger `-TimeoutSec` to `Wait-Video` or `Get-VideoContent`.
+- Always verify the final `status` property (`completed` or `succeeded`) before assuming the media is usable.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Install-Module -Name PSOpenAI
 
 ### OpenAI
 #### Chat
-[Guide: How to use Chat](/Guides/How_to_use_Chat.md)
+Guide: [How to use Chat](/Guides/How_to_use_Chat.md)
 
 + [Enter-ChatGPT](/Docs/Enter-ChatGPT.md)
 + [Request-ChatCompletion](/Docs/Request-ChatCompletion.md)
@@ -57,7 +57,7 @@ Install-Module -Name PSOpenAI
 + [New-ChatCompletionFunction](/Docs/New-ChatCompletionFunction.md)
 
 #### Responses
-[Guide: Migrate ChatCompletion to Response](/Guides/Migrate_ChatCompletion_to_Response.md)  
+Guide: [Migrate ChatCompletion to Response](/Guides/Migrate_ChatCompletion_to_Response.md)  
 
 + [Request-Response](/Docs/Request-Response.md)
 + [Get-Response](/Docs/Get-Response.md)
@@ -74,8 +74,8 @@ Install-Module -Name PSOpenAI
 + [Remove-ConversationItem](/Docs/Remove-ConversationItem.md)
 
 #### Assistants
-[Guide: How to use Assistants](/Guides/How_to_use_Assistants.md)  
-[Guide: How to use File search with Assistants and Vector Store](/Guides/How_to_use_FileSearch_with_VectorStore.md)
+Guide: [How to use Assistants](/Guides/How_to_use_Assistants.md)  
+Guide: [How to use File search with Assistants and Vector Store](/Guides/How_to_use_FileSearch_with_VectorStore.md)
 
 + [Get-Assistant](/Docs/Get-Assistant.md)
 + [New-Assistant](/Docs/New-Assistant.md)
@@ -108,7 +108,7 @@ Install-Module -Name PSOpenAI
 + [Get-VectorStoreFileInBatch](/Docs/Get-VectorStoreFileInBatch.md)
 
 #### Realtime
-[Guide: How to use Realtime API](/Guides/How_to_use_Realtime_API.md)  
+Guide: [How to use Realtime API](/Guides/How_to_use_Realtime_API.md)  
 
 + [Connect-RealtimeSession](/Docs/Connect-RealtimeSession.md)
 + [Connect-RealtimeTranscriptionSession](/Docs/Connect-RealtimeTranscriptionSession.md)
@@ -138,6 +138,8 @@ Install-Module -Name PSOpenAI
 + [Request-AudioTranslation](/Docs/Request-AudioTranslation.md)
 
 #### Videos
+Guide: [How to use Video generation](/Guides/How_to_use_Video_generation.md)
+
 + [New-Video](/Docs/New-Video.md)
 + [New-VideoRemix](/Docs/New-VideoRemix.md)
 + [Get-Video](/Docs/Get-Video.md)
@@ -151,7 +153,7 @@ Install-Module -Name PSOpenAI
 + [Get-OpenAIFileContent](/Docs/Get-OpenAIFileContent.md)
 
 #### Batch
-[Guide: How to use Batch](/Guides/How_to_use_Batch.md)
+Guide: [How to use Batch](/Guides/How_to_use_Batch.md)
 
 + [Start-Batch](/Docs/Start-Batch.md)
 + [Get-Batch](/Docs/Get-Batch.md)
@@ -168,7 +170,7 @@ Install-Module -Name PSOpenAI
 + [Remove-ContainerFile](/Docs/Remove-ContainerFile.md)
 + [Get-ContainerFileContent](/Docs/Get-ContainerFileContent.md)
 
-#### Others
+### Others
 + [Get-OpenAIModels](/Docs/Get-OpenAIModels.md)
 + [Request-Embeddings](/Docs/Request-Embeddings.md)
 + [Request-Moderation](/Docs/Request-Moderation.md)


### PR DESCRIPTION
## Summary
- add a guide in the Guides folder covering the video generation cmdlets
- provide end-to-end examples for creating, monitoring, downloading, remixing, and cleaning up video jobs

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ebb36d5d2c83258da3d12945309883